### PR TITLE
misc build Actions cleanups

### DIFF
--- a/.github/workflows/build-package.yml.template
+++ b/.github/workflows/build-package.yml.template
@@ -19,12 +19,12 @@ jobs:
         shell: bash
     steps:
       - name: Checkout trigger commit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           path: trigger
       - name: Checkout main repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           ref: $BRANCH
@@ -53,7 +53,7 @@ jobs:
       # TODO: try breaking things so that uploads don't work.
 
       - name: Create binary artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: built-$BUILD_OS
           path: ${{github.workspace}}/built.d
@@ -66,13 +66,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout trigger commit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.CRONJOB_DEPLOY_KEY }}
           persist-credentials: true
           path: trigger
       - name: Checkout main repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           # TODO: maybe this should be main or configurable or something?
@@ -80,24 +80,24 @@ jobs:
           path: cargo-quickinstall
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: built-$BUILD_OS
           # TODO: check that we it can't write anywhere other than built.d
           path: ${{github.workspace}}/built.d
 
       - name: Check if tarball exists
-        id: check_files
-        uses: andstor/file-existence-action@v1
+        id: check_files_2
+        uses: andstor/file-existence-action@v2
         with:
           files: ${{github.workspace}}/built.d/$CRATE-$VERSION-$TARGET_ARCH.tar.gz
 
       - name: Cancel if no tarball
-        if: steps.check_files.outputs.files_exists == 'false'
+        if: steps.check_files_2.outputs.files_exists == 'false'
         uses: andymckay/cancel-action@0.2
 
       - name: Wait for cancellation signal if no tarball
-        if: steps.check_files.outputs.files_exists == 'false'
+        if: steps.check_files_2.outputs.files_exists == 'false'
         run: |
           sleep 1m
           exit 1

--- a/.github/workflows/build-package.yml.template
+++ b/.github/workflows/build-package.yml.template
@@ -47,18 +47,18 @@ jobs:
           export VERSION=$VERSION
 
           cargo-quickinstall/build-version.sh "${CRATE}"
+          touch $TEMPDIR/dummy-file
           ls $TEMPDIR
       # At this point, I don't think that you can really trust anything on the system anymore.
       # I'm not sure whether the js actions runtime is also affected by this.
       # TODO: try breaking things so that uploads don't work.
 
-      - name: Create binary artifact
+      - name: Upload run-local binary artifact
         uses: actions/upload-artifact@v3
         with:
           name: built-$BUILD_OS
           path: ${{github.workspace}}/built.d
           if-no-files-found: error
-
 
   upload-popular-package:
     name: Upload
@@ -87,17 +87,17 @@ jobs:
           path: ${{github.workspace}}/built.d
 
       - name: Check if tarball exists
-        id: check_files_2
+        id: check_files
         uses: andstor/file-existence-action@v2
         with:
           files: ${{github.workspace}}/built.d/$CRATE-$VERSION-$TARGET_ARCH.tar.gz
 
       - name: Cancel if no tarball
-        if: steps.check_files_2.outputs.files_exists == 'false'
-        uses: andymckay/cancel-action@0.2
+        if: steps.check_files.outputs.files_exists == 'false'
+        uses: andymckay/cancel-action@0.3
 
       - name: Wait for cancellation signal if no tarball
-        if: steps.check_files_2.outputs.files_exists == 'false'
+        if: steps.check_files.outputs.files_exists == 'false'
         run: |
           sleep 1m
           exit 1

--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -1,13 +1,9 @@
 name: Cronjob
 
 # Run every hour on the hour.
-# `actions` is the name of my prototyping branch, so also run this job when I push there.
 on:
   schedule:
     - cron: "0 * * * *"
-  push:
-    branches:
-      - actions
 
 jobs:
   build-popular-package:

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -35,14 +35,14 @@ jobs:
         run: |
           set -euxo pipefail
           touch .env
-          VERSION=$(
+          VERSION="$(
             curl \
               --user-agent "cargo-quickinstall build pipeline (alsuren@gmail.com)" \
               --fail "https://crates.io/api/v1/crates/cargo-quickinstall" \
               | jq -r '.versions[0].num'
-          )
-          env VERSION=$VERSION TARGET_ARCH=$TARGET_ARCH ./build-version.sh cargo-quickinstall
-          env ALWAYS_BUILD=1 VERSION=$VERSION TARGET_ARCH=$TARGET_ARCH ./build-version.sh cargo-quickinstall
+          )"
+          VERSION="$VERSION" TARGET_ARCH="$TARGET_ARCH" ./build-version.sh cargo-quickinstall
+          ALWAYS_BUILD=1 VERSION="$VERSION" TARGET_ARCH="$TARGET_ARCH" ./build-version.sh cargo-quickinstall
       - name: Install Thyself
         run: cargo install --path cargo-quickinstall
       - name: Install Thyself with Thyself (or fallback to sensei on windows)

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -39,7 +39,7 @@ jobs:
             curl \
               --user-agent "cargo-quickinstall build pipeline (alsuren@gmail.com)" \
               --fail "https://crates.io/api/v1/crates/cargo-quickinstall" \
-              | jq -r .versions[0].num
+              | jq -r '.versions[0].num'
           )
           env VERSION=$VERSION TARGET_ARCH=$TARGET_ARCH ./build-version.sh cargo-quickinstall
           env ALWAYS_BUILD=1 VERSION=$VERSION TARGET_ARCH=$TARGET_ARCH ./build-version.sh cargo-quickinstall

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Clippy
         run: cargo clippy
 
+      - name: Shellcheck
+        run: shellcheck *.sh
+
   test:
     name: Test runner
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Fetch source
         uses: actions/checkout@v3
 
+      - name: Shellcheck
+        run: shellcheck *.sh
+
       - name: Lint
         run: cargo fmt --check
 
       - name: Clippy
         run: cargo clippy
-
-      - name: Shellcheck
-        run: shellcheck *.sh
 
   test:
     name: Test runner

--- a/build-version.sh
+++ b/build-version.sh
@@ -60,6 +60,6 @@ done
 #
 # BINARIES is a space-separated list of files, so it can't be quoted
 # shellcheck disable=SC2086
-tar --format=v7 -czf "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz" $BINARIES
+tar --format=v7 -c $BINARIES | gzip -9 -c >"${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"
 
 echo "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"

--- a/build-version.sh
+++ b/build-version.sh
@@ -40,14 +40,14 @@ else
 fi
 
 BINARIES=$(
-    cat $CRATES2_JSON_PATH | jq -r '
-        .installs | to_entries[] | select(.key|startswith("'${CRATE}' ")) | .value.bins | .[]
-    ' | tr '\r' ' '
+    jq -r '
+        .installs | to_entries[] | select(.key|startswith("'"${CRATE}"' ")) | .value.bins | .[]
+    ' "$CRATES2_JSON_PATH" | tr '\r' ' '
 )
 
-cd $CARGO_BIN_DIR
+cd "$CARGO_BIN_DIR"
 for file in $BINARIES; do
-    if file $file | grep ': data$'; then
+    if file "$file" | grep ': data$'; then
         echo "something wrong with $file. Should be recognised as executable."
         exit 1
     fi
@@ -57,6 +57,9 @@ done
 #
 # TODO: maybe we want to make a ~/.cargo-quickinstall/bin to untar into,
 # and add symlinks into ~/.cargo/bin, to aid debugging?
+#
+# BINARIES is a space-separated list of files, so it can't be quoted
+# shellcheck disable=SC2086
 tar --format=v7 -czf "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz" $BINARIES
 
 echo "${TEMPDIR}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -178,6 +178,7 @@ fn curl_head(url: &str) -> Result<Vec<u8>, InstallError> {
         .arg("--silent")
         .arg("--show-error")
         .arg("--fail")
+        .arg("--location")
         .arg(url)
         .output()?;
     if !output.status.success() {

--- a/check-packages.sh
+++ b/check-packages.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2002
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -14,7 +13,7 @@ function check_packages() {
         if [[ ! -d "$TEMPDIR/$tag" ]]; then
             curl --silent --location --fail "${GITHUB}/${tag}/${tag}.tar.gz" > "$TEMPDIR/$tag.tar.gz"
             mkdir "$TEMPDIR/$tag"
-            cat "$TEMPDIR/$tag.tar.gz" | tar -xzf - -C "$TEMPDIR/$tag"
+            tar -xzf "$TEMPDIR/$tag.tar.gz" -C "$TEMPDIR/$tag"
             rm "$TEMPDIR/$tag.tar.gz"
         fi
         for file in "$TEMPDIR/$tag/"*; do

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -30,7 +30,8 @@ POPULAR_CRATES=$(
       grep -v '/' |
       grep -A1000 --line-regexp "${START_AFTER_CRATE:-.*}" |
       # drop the first line (the one that matched)
-      tail -n +2 ||
+      tail -n +2 |
+      tail -n "${CRATE_CHECK_LIMIT:=-1000}" ||
       # If we don't find anything (package stopped being popular?)
       # then fall back to doing a self-build.
       echo 'cargo-quickinstall'

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -48,10 +48,14 @@ for CRATE in $POPULAR_CRATES; do
     continue
   fi
 
-  rm -rf "$TEMPDIR/crates.io-response.json"
-  curl_slowly --location --fail "https://crates.io/api/v1/crates/${CRATE}" >"$TEMPDIR/crates.io-response.json"
-  VERSION=$(cat "$TEMPDIR/crates.io-response.json" | jq -r .versions[0].num)
-  LICENSE=$(cat "$TEMPDIR/crates.io-response.json" | jq -r .versions[0].license | sed -e 's:/:", ":g' -e 's/ OR /", "/g')
+  RESPONSE_DIR="$TEMPDIR/crates.io-responses/"
+  RESPONSE_FILENAME="$RESPONSE_DIR/$CRATE.json"
+  if [[ ! -f "$RESPONSE_FILENAME" ]]; then
+    mkdir -p "$RESPONSE_DIR"
+    curl_slowly --location --fail "https://crates.io/api/v1/crates/${CRATE}" >"$RESPONSE_FILENAME"
+  fi
+  VERSION=$(cat "$RESPONSE_FILENAME" | jq -r .versions[0].num)
+  LICENSE=$(cat "$RESPONSE_FILENAME" | jq -r .versions[0].license | sed -e 's:/:", ":g' -e 's/ OR /", "/g')
 
   if curl_slowly --fail -I --output /dev/null "https://github.com/alsuren/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
     echo "${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz already uploaded. Keep going." 1>&2

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -55,8 +55,7 @@ for CRATE in $POPULAR_CRATES; do
     mkdir -p "$RESPONSE_DIR"
     curl_slowly --location --fail "https://crates.io/api/v1/crates/${CRATE}" >"$RESPONSE_FILENAME"
   fi
-  VERSION=$(cat "$RESPONSE_FILENAME" | jq -r .versions[0].num)
-  LICENSE=$(cat "$RESPONSE_FILENAME" | jq -r .versions[0].license | sed -e 's:/:", ":g' -e 's/ OR /", "/g')
+  VERSION=$(jq -r '.versions[0].num' "$RESPONSE_FILENAME")
 
   if curl_slowly --fail -I --output /dev/null "https://github.com/alsuren/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
     echo "${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz already uploaded. Keep going." 1>&2

--- a/rebuild-popular-crates.sh
+++ b/rebuild-popular-crates.sh
@@ -34,7 +34,7 @@ function get_top_both() {
 
 function get_new_file_contents() {
     (
-        cat popular-crates.txt | grep -B10000 '####################################'
+        grep -B10000 '####################################' popular-crates.txt
         get_top_both
     ) | uq
 }

--- a/trigger-package-build.sh
+++ b/trigger-package-build.sh
@@ -38,6 +38,10 @@ main() {
 
     TARGET_ARCHES="${TARGET_ARCHES:-${TARGET_ARCH:-x86_64-pc-windows-msvc x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-linux-gnu x86_64-unknown-linux-musl}}"
 
+    if [ ! -d "${TEMPDIR:-}" ]; then
+        TEMPDIR="$(mktemp -d)"
+    fi
+
     for TARGET_ARCH in $TARGET_ARCHES; do
         BUILD_OS=$(get_build_os "$TARGET_ARCH")
 
@@ -77,10 +81,15 @@ main() {
             START_AFTER_CRATE=''
         fi
 
+        if [[ "$RECHECK" != "1" ]]; then
+            rm -rf "$TEMPDIR/crates.io-responses"
+        fi
+
         env START_AFTER_CRATE="$START_AFTER_CRATE" \
             TARGET_ARCH="$TARGET_ARCH" \
             EXCLUDE_FILE="$EXCLUDE_FILE" \
             RECHECK="$RECHECK" \
+            TEMPDIR="$TEMPDIR" \
             "$REPO_ROOT/next-unbuilt-package.sh" >package-info.txt
 
         CRATE=$(

--- a/trigger-package-build.sh
+++ b/trigger-package-build.sh
@@ -30,6 +30,7 @@ main() {
     # a build of cargo-quickinstall.
     if [[ "${BRANCH:-}" == "actions" && "${CI:-}" == "true" ]]; then
         CRATE_CHECK_LIMIT=10
+        FORCE=1
     else
         CRATE_CHECK_LIMIT=1000
     fi

--- a/trigger-package-build.sh
+++ b/trigger-package-build.sh
@@ -25,6 +25,15 @@ main() {
     BRANCH=$(git branch --show-current)
     RECHECK="${RECHECK:-}"
 
+    # If we are on the `actions` branch, it's because we're trying to develop a feature.
+    # Mostly we want just want it to check a few packages and then fall back to triggering
+    # a build of cargo-quickinstall.
+    if [[ "${BRANCH:-}" == "actions" && "${CI:-}" == "true" ]]; then
+        CRATE_CHECK_LIMIT=10
+    else
+        CRATE_CHECK_LIMIT=1000
+    fi
+
     if [[ ${FORCE:-} == 1 ]]; then
      ALLOW_EMPTY=--allow-empty
     else
@@ -90,6 +99,7 @@ main() {
             EXCLUDE_FILE="$EXCLUDE_FILE" \
             RECHECK="$RECHECK" \
             TEMPDIR="$TEMPDIR" \
+            CRATE_CHECK_LIMIT="$CRATE_CHECK_LIMIT" \
             "$REPO_ROOT/next-unbuilt-package.sh" >package-info.txt
 
         CRATE=$(

--- a/trigger-package-build.sh
+++ b/trigger-package-build.sh
@@ -118,15 +118,14 @@ main() {
         mkdir -p .github/workflows/
 
         # I like cat. Shut up.
-        # shellcheck disable=SC2002
-        cat "$REPO_ROOT/.github/workflows/build-package.yml.template" |
-            sed \
-                -e s/'[$]CRATE'/"$CRATE"/ \
-                -e s/'[$]VERSION'/"$VERSION"/ \
-                -e s/'[$]TARGET_ARCH'/"$TARGET_ARCH"/ \
-                -e s/'[$]BUILD_OS'/"$BUILD_OS"/ \
-                -e s/'[$]BRANCH'/"$BRANCH"/ \
-                > ".github/workflows/build-package-$TARGET_ARCH.yml"
+        sed \
+            -e s/'[$]CRATE'/"$CRATE"/ \
+            -e s/'[$]VERSION'/"$VERSION"/ \
+            -e s/'[$]TARGET_ARCH'/"$TARGET_ARCH"/ \
+            -e s/'[$]BUILD_OS'/"$BUILD_OS"/ \
+            -e s/'[$]BRANCH'/"$BRANCH"/ \
+            "$REPO_ROOT/.github/workflows/build-package.yml.template" \
+            > ".github/workflows/build-package-$TARGET_ARCH.yml"
 
         # FIXME: I don't think we need package-info.txt anymore.
         git add package-info.txt ".github/workflows/build-package-$TARGET_ARCH.yml"

--- a/trigger-package-build.sh
+++ b/trigger-package-build.sh
@@ -131,6 +131,10 @@ main() {
         git add package-info.txt ".github/workflows/build-package-$TARGET_ARCH.yml"
         git --no-pager diff HEAD
 
+        # $ALLOW_EMPTY is either --allow-empty or the empty string.
+        # Adding quotes around this would add an empty positional argument to git,
+        # which it would reject.
+        # shellcheck disable=SC2086
         if ! git commit $ALLOW_EMPTY -am "build $CRATE $VERSION on $TARGET_ARCH"; then
             echo "looks like there's nothing to push"
             continue


### PR DESCRIPTION
I thought I might as well clean some long-serving uglinesses up before I hand them over. Hopefully the code review process will act as a way for @NobodyXu to learn how things work ;-)

This vaguely relates to #26 I guess.

Probably best to review things commit-by-commit. I didn't write them in that order, but the commits should be self-contained after my rebasing.

pushing to the actions branch (with a PR open against it) now triggers the following cascade (oldest at the bottom):

<img width="951" alt="Screenshot 2022-12-27 at 23 49 02" src="https://user-images.githubusercontent.com/254647/209738696-728436d9-f60d-4641-981a-3439c59108f5.png">

(you can ignore the `Automated Tests` and `Self-Build` actions)

* "weekly recheck" is triggered (as a hack) 
* it runs `make recheck` which runs `trigger-package-build.sh`
* `trigger-package-build.sh` fills in .github/workflows/build-package.yml.template a bunch of times, and pushes each to the appropriate trigger/$arch branch. It sets FORCE=1 so these pushes are likely to be empty commits (`git commit --allow-empty`)
* Each push triggers a "Build for $arch" build for cargo-quickinstall, because there is nothing else to build (it only checks 10 packages anyway, because waiting 20 minutes for every change on the `actions` branch was getting really boring)
* each build quickly realises that cargo-quickinstall is already packaged, so there is nothing to do. It then cancels itself (previously it was set up to cancel itself, but it would die before getting to that step).