### PR TITLE
update to point at cargo-bins org

### DIFF
--- a/.github/workflows/build-package.yml.template
+++ b/.github/workflows/build-package.yml.template
@@ -2,7 +2,7 @@ name: Build for $TARGET_ARCH
 
 # Triggered by push from cronjob.
 # $CRATE, $VERSION, $TARGET_ARCH, $BRANCH and $BUILD_OS are replaced using sed.
-# Title of job in https://github.com/alsuren/cargo-quickinstall/actions
+# Title of job in https://github.com/cargo-bins/cargo-quickinstall/actions
 # is set by the commit message, which is created by trigger-package-build.sh
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ cargo-quickinstall --dry-run ripgrep
 will print:
 
 ```bash
-"curl" "--user-agent" "cargo-quickinstall client (alsuren@gmail.com)" "--location" "--silent" "--show-error" "--fail" "https://github.com/alsuren/cargo-quickinstall/releases/download/ripgrep-13.0.0-x86_64-apple-darwin/ripgrep-13.0.0-x86_64-apple-darwin.tar.gz" | "tar" "-xzvvf" "-" "-C" "/Users/alsuren/.cargo/bin"
+"curl" "--user-agent" "cargo-quickinstall client (alsuren@gmail.com)" "--location" "--silent" "--show-error" "--fail" "https://github.com/cargo-bins/cargo-quickinstall/releases/download/ripgrep-13.0.0-x86_64-apple-darwin/ripgrep-13.0.0-x86_64-apple-darwin.tar.gz" | "tar" "-xzvvf" "-" "-C" "/Users/alsuren/.cargo/bin"
 ```
 
 Edit the command however you need, and paste it into your CI pipeline.
@@ -69,7 +69,7 @@ There are a few pieces of infrastructure that are also part of this project:
 
 There are a lot of things to figure out at the moment, so now is the perfect time to jump in and help. I created a [Gitter](https://gitter.im/cargo-quickinstall/community) room for collaborating in. You can also poke [@alsuren](https://twitter.com/alsuren) on Twitter or Discord. I'm also up for pairing over zoom to get new contributors onboarded.
 
-Work is currently tracked on [the kanban board](https://github.com/alsuren/cargo-quickinstall/projects/1?fullscreen=true). If you want help breaking down a ticket, give me a shout in one of the above places.
+Work is currently tracked on [the kanban board](https://github.com/orgs/cargo-bins/projects/1). If you want help breaking down a ticket, give me a shout in one of the above places.
 
 ## Releasing
 

--- a/build-version.sh
+++ b/build-version.sh
@@ -16,7 +16,7 @@ curl_slowly() {
     sleep 1 && curl --user-agent "cargo-quickinstall build pipeline (alsuren@gmail.com)" "$@"
 }
 
-if [ "${ALWAYS_BUILD:-}" != 1 ] && curl_slowly --fail -I --output /dev/null "https://github.com/alsuren/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
+if [ "${ALWAYS_BUILD:-}" != 1 ] && curl_slowly --fail -I --output /dev/null "https://github.com/cargo-bins/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
     echo "${CRATE}/${VERSION}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz already uploaded. Skipping."
     exit 0
 fi

--- a/cargo-quickinstall/Cargo.toml
+++ b/cargo-quickinstall/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Precompiled binary installs for `cargo install`"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
-repository = "https://github.com/alsuren/cargo-quickinstall"
+repository = "https://github.com/cargo-bins/cargo-quickinstall"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -112,7 +112,7 @@ pub fn report_stats_in_background(details: &CrateDetails) -> std::thread::JoinHa
 
 pub fn do_dry_run(crate_details: &CrateDetails) -> String {
     let crate_download_url = format!(
-        "https://github.com/alsuren/cargo-quickinstall/releases/download/\
+        "https://github.com/cargo-bins/cargo-quickinstall/releases/download/\
                  {crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz",
         crate_name = crate_details.crate_name,
         version = crate_details.version,
@@ -228,7 +228,7 @@ fn download_tarball(
     target: &str,
 ) -> Result<Vec<u8>, InstallError> {
     let github_url = format!(
-        "https://github.com/alsuren/cargo-quickinstall/releases/download/{crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz",
+        "https://github.com/cargo-bins/cargo-quickinstall/releases/download/{crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz",
         crate_name=crate_name, version=version, target=target,
     );
     curl_bytes(&github_url)

--- a/cargo-quickinstall/tests/integration_tests.rs
+++ b/cargo-quickinstall/tests/integration_tests.rs
@@ -38,7 +38,7 @@ fn do_dry_run_for_ripgrep() {
 
     let result = do_dry_run(&crate_details);
 
-    let expected_prefix = r#""curl" "--user-agent" "cargo-quickinstall client (alsuren@gmail.com)" "--location" "--silent" "--show-error" "--fail" "https://github.com/alsuren/cargo-quickinstall/releases/download/ripgrep-13.0.0-x86_64-unknown-linux-gnu/ripgrep-13.0.0-x86_64-unknown-linux-gnu.tar.gz" | "tar" "-xzvvf" "-" "-C""#;
+    let expected_prefix = r#""curl" "--user-agent" "cargo-quickinstall client (alsuren@gmail.com)" "--location" "--silent" "--show-error" "--fail" "https://github.com/cargo-bins/cargo-quickinstall/releases/download/ripgrep-13.0.0-x86_64-unknown-linux-gnu/ripgrep-13.0.0-x86_64-unknown-linux-gnu.tar.gz" | "tar" "-xzvvf" "-" "-C""#;
     assert!(result.starts_with(expected_prefix));
 }
 

--- a/check-packages.sh
+++ b/check-packages.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-GITHUB="https://github.com/alsuren/cargo-quickinstall/releases/download"
+GITHUB="https://github.com/cargo-bins/cargo-quickinstall/releases/download"
 TEMPDIR=/tmp/check-packages
 mkdir -p "$TEMPDIR"
 

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -53,7 +53,7 @@ for CRATE in $POPULAR_CRATES; do
   VERSION=$(cat "$TEMPDIR/crates.io-response.json" | jq -r .versions[0].num)
   LICENSE=$(cat "$TEMPDIR/crates.io-response.json" | jq -r .versions[0].license | sed -e 's:/:", ":g' -e 's/ OR /", "/g')
 
-  if curl_slowly --fail -I --output /dev/null "https://github.com/alsuren/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
+  if curl_slowly --fail -I --output /dev/null "https://github.com/cargo-bins/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
     echo "${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz already uploaded. Keep going." 1>&2
   else
     echo "${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz needs building" 1>&2


### PR DESCRIPTION
Since github automatically does http redirects to the new org, there's very little left to do on #58 .

Once this is merged, we should probably make a release https://github.com/cargo-bins/cargo-quickinstall#releasing but there's no urgency - everything seems to be trucking along as usual. The only thing that broke with the rename was that `--dry-run` thinks that we have a package for everything.

I can do the release + announcement if you want, to announce the handover.

I think the only thing that's left after this is rotating secrets.CRONJOB_DEPLOY_KEY