### PR TITLE
Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "cargo-quickinstall"
-version = "0.2.7-alpha.0"
+version = "0.2.7"
 dependencies = [
  "home",
  "mktemp",

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ publish: release ## alias for `make release`
 
 .PHONY: release
 release: ## Publish a new release
-	(cd cargo-quickinstall/ && cargo release patch --dev-version --execute)
+	(cd cargo-quickinstall/ && cargo release patch --execute)
 	make recheck
 
 .PHONY: windows

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ publish: release ## alias for `make release`
 
 .PHONY: release
 release: ## Publish a new release
-	(cd cargo-quickinstall/ && cargo release patch --execute)
+	(cd cargo-quickinstall/ && cargo release patch --execute --no-push)
+	git push origin HEAD:release --tags
 	make recheck
 
 .PHONY: windows

--- a/cargo-quickinstall/Cargo.toml
+++ b/cargo-quickinstall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-quickinstall"
-version = "0.2.7-alpha.0"
+version = "0.2.7"
 authors = ["David Laban <david.laban@red-badger.com>"]
 edition = "2018"
 description = "Precompiled binary installs for `cargo install`"


### PR DESCRIPTION
I made a release and it seems to have built fine.

`make release` needed some tweaks because `cargo-release` has changed, and I added branch protection on main since I last did a release.

It might be possible to use a github action to do the release, to avoid this "release pr" nonsense. What does cargo-binstall do?

I will announce it this afternoon/evening.