### PR TITLE
Actions

### DIFF
--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -57,7 +57,7 @@ for CRATE in $POPULAR_CRATES; do
     fi
     VERSION=$(jq -r '.versions[0].num' "$RESPONSE_FILENAME")
 
-    if curl_slowly --fail -I --output /dev/null "https://github.com/cargo-bins/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
+    if curl_slowly --location --fail -I --output /dev/null "https://github.com/cargo-bins/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
         echo "${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz already uploaded. Keep going." 1>&2
     else
         echo "${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz needs building" 1>&2

--- a/popular-crates.txt
+++ b/popular-crates.txt
@@ -1,12 +1,49 @@
 # To re-generate this list, run ./rebuild-popular-crates.sh and then audit any new entries.
 # Crates from contributors go to the top of the list :D.
 #
+# There are also a few packages that we know people are using in ci or something,
+# that don't always get built. To find popular packages, pick a date and run something like:
+#
+# ```python
+# import pandas
+#
+# df = pandas.read_json("https://raw.githubusercontent.com/cargo-bins/cargo-quickinstall/197c2baa62309bc2458c2f9a8190de3711116870/stats/tidy.jsonl", lines=True)
+# df[
+#    df["build_date"].isnull() & (df["date"] > "2022-12-01")
+# ].groupby(
+#    ['package', 'arch']
+# )['count'].sum().reset_index().sort_values('count', ascending=False).head(20)
+# ```
+#
+# and then paste the result down here.
+#
 # The first empty line is important. I can't remember why.
 
 cargo-quickinstall
 sensei
 ripgrep
 cargo-make
+sarif-fmt
+clippy-sarif
+grcov
+cargo-tarpaulin
+cargo-binstall
+cocogitto
+cargo-deny
+mdbook
+taplo-cli
+mdbook-linkcheck
+cargo-udeps
+cargo-spellcheck
+cargo-sync-rdme
+wasm-bindgen-cli
+dprint
+cargo-chef
+sccache
+semantic-release-cargo
+zellij
+topgrade
+cargo-generate
 ####################################
 b3sum
 bandwhich


### PR DESCRIPTION
When I was playing around with plotting graphs, I noticed that there were a bunch of packages that we hadn't built yet.

(data is from the `stats` branch - https://github.com/cargo-bins/cargo-quickinstall/blob/stats/stats/fetch.py . `build_date` is calculated by checking for the existence of build tags rather than fetching from github releases, because I thought it would be quicker)

```python
import pandas

df = pandas.read_json("https://raw.githubusercontent.com/cargo-bins/cargo-quickinstall/197c2baa62309bc2458c2f9a8190de3711116870/stats/tidy.jsonl", lines=True)
df[
    df["build_date"].isnull() & (df["date"] > "2022-12-01") & (df["arch"] == "x86_64-unknown-linux-gnu")
].groupby(
    ['package']
)['count'].sum().reset_index().sort_values('count', ascending=False).head(20)
```

| package                |   count |
|:-----------------------|--------:|
| sarif-fmt              |    1290 |
| clippy-sarif           |    1265 |
| cargo-binstall         |    1205 |
| grcov                  |     759 |
| cargo-llvm-cov         |     655 |
| cargo-nextest          |     640 |
| mdbook                 |     483 |
| taplo-cli              |     388 |
| mdbook-linkcheck       |     334 |
| cargo-udeps            |     330 |
| cargo-spellcheck       |     312 |
| cargo-sync-rdme        |     258 |
| wasm-bindgen-cli       |     256 |
| dprint                 |     213 |
| cargo-chef             |     143 |
| sccache                |     129 |
| semantic-release-cargo |     115 |
| zellij                 |     112 |
| topgrade               |     110 |
| cargo-generate         |     103 |

I added the --location flag and ran `TARGET_ARCH=x86_64-unknown-linux-gnu ./trigger-package-build.sh` a bunch of times locally.