### PR TITLE
Use `cargo-binstall` instead of `curl | tar` by default

### DIFF
--- a/cargo-quickinstall/src/args.rs
+++ b/cargo-quickinstall/src/args.rs
@@ -10,6 +10,7 @@ OPTIONS:
         --version <VERSION>         Specify a version to install
         --target <TRIPLE>           Install package for the target triple
         --no-fallback               Don't fall back to `cargo install`
+        --no-binstall               Don't use `cargo binstall` to install packages.
         --dry-run                   Print the `curl | tar` command that would be run to fetch the binary
     -V, --print-version             Print version info and exit
     -h, --help                      Prints help information
@@ -20,6 +21,7 @@ pub struct CliOptions {
     pub target: Option<String>,
     pub crate_name: Option<String>,
     pub fallback: bool,
+    pub no_binstall: bool,
     pub print_version: bool,
     pub help: bool,
     pub dry_run: bool,
@@ -32,6 +34,7 @@ pub fn options_from_cli_args(
         version: args.opt_value_from_str("--version")?,
         target: args.opt_value_from_str("--target")?,
         fallback: !args.contains("--no-fallback"),
+        no_binstall: !args.contains("--no-binstall"),
         print_version: args.contains(["-V", "--print-version"]),
         help: args.contains(["-h", "--help"]),
         dry_run: args.contains("--dry-run"),

--- a/cargo-quickinstall/src/args.rs
+++ b/cargo-quickinstall/src/args.rs
@@ -34,7 +34,7 @@ pub fn options_from_cli_args(
         version: args.opt_value_from_str("--version")?,
         target: args.opt_value_from_str("--target")?,
         fallback: !args.contains("--no-fallback"),
-        no_binstall: !args.contains("--no-binstall"),
+        no_binstall: args.contains("--no-binstall"),
         print_version: args.contains(["-V", "--print-version"]),
         help: args.contains(["-h", "--help"]),
         dry_run: args.contains("--dry-run"),

--- a/cargo-quickinstall/src/install_error.rs
+++ b/cargo-quickinstall/src/install_error.rs
@@ -12,14 +12,11 @@ pub enum InstallError {
 
 impl InstallError {
     pub fn is_curl_404(&self) -> bool {
-        match self {
+        matches!(
+            self,
             Self::CommandFailed(CommandFailed { stderr, .. })
-                if stderr.contains("curl: (22) The requested URL returned error: 404") =>
-            {
-                true
-            }
-            _ => false,
-        }
+            if stderr.contains("curl: (22) The requested URL returned error: 404")
+        )
     }
 }
 

--- a/cargo-quickinstall/src/install_error.rs
+++ b/cargo-quickinstall/src/install_error.rs
@@ -20,7 +20,15 @@ impl InstallError {
     }
 }
 
-impl std::error::Error for InstallError {}
+impl std::error::Error for InstallError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        if let Self::IoError(io_err) = self {
+            Some(io_err)
+        } else {
+            None
+        }
+    }
+}
 
 // We implement `Debug` in terms of `Display`, because "Error: {:?}"
 // is what is shown to the user if you return an error from `main()`.

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -25,6 +25,18 @@ pub struct CrateDetails {
     pub target: String,
 }
 
+pub fn get_cargo_binstall_version() -> Option<String> {
+    let output = std::process::Command::new("cargo")
+        .args(["binstall", "-V"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout).ok()
+}
+
 pub fn install_crate_curl(details: &CrateDetails, fallback: bool) -> Result<(), InstallError> {
     match download_tarball(&details.crate_name, &details.version, &details.target) {
         Ok(tarball) => {

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -25,7 +25,7 @@ pub struct CrateDetails {
     pub target: String,
 }
 
-pub fn install_crate(details: &CrateDetails, fallback: bool) -> Result<(), InstallError> {
+pub fn install_crate_curl(details: &CrateDetails, fallback: bool) -> Result<(), InstallError> {
     match download_tarball(&details.crate_name, &details.version, &details.target) {
         Ok(tarball) => {
             let tar_output = untar(tarball)?;
@@ -110,7 +110,7 @@ pub fn report_stats_in_background(details: &CrateDetails) -> std::thread::JoinHa
     })
 }
 
-pub fn do_dry_run(crate_details: &CrateDetails) -> String {
+pub fn do_dry_run_curl(crate_details: &CrateDetails) -> String {
     let crate_download_url = format!(
         "https://github.com/cargo-bins/cargo-quickinstall/releases/download/\
                  {crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz",

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -109,7 +109,7 @@ fn do_main_binstall(
     version: Option<String>,
     target: Option<String>,
     dry_run: bool,
-    fallback: bool,
+    _fallback: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let is_binstall_compatible = get_cargo_binstall_version()
         .map(
@@ -129,10 +129,12 @@ fn do_main_binstall(
         .unwrap_or(false);
 
     if !is_binstall_compatible {
-        do_main_curl("cargo-binstall".to_string(), None, None, dry_run, fallback)?;
+        do_main_curl("cargo-binstall".to_string(), None, None, dry_run, false)?;
 
         if !dry_run {
-            println!("Bootstrapping cargo-binstall with itself to make `cargo uninstall ` work properly");
+            println!(
+                "Bootstrapping cargo-binstall with itself to make `cargo uninstall ` work properly"
+            );
             do_install_binstall(
                 vec![Crate {
                     name: "cargo-binstall".to_string(),

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -132,7 +132,7 @@ fn do_main_binstall(
         do_main_curl("cargo-binstall".to_string(), None, None, dry_run, fallback)?;
 
         if !dry_run {
-            println!("Bootstrap cargo-binstall itself to update $CARGO_HOME/.crates.toml");
+            println!("Bootstrapping cargo-binstall with itself to make `cargo uninstall ` work properly");
             do_install_binstall(
                 vec![Crate {
                     name: "cargo-binstall".to_string(),

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -187,9 +187,9 @@ fn do_install_binstall(
     if !status.success() {
         Err(format!(
             "`{} {}` failed with {status}",
-            cmd.get_program().to_string_lossy().into_owned(),
+            cmd.get_program().to_string_lossy(),
             cmd.get_args()
-                .map(|arg| arg.to_string_lossy().into_owned())
+                .map(|arg| arg.to_string_lossy())
                 .collect::<Vec<_>>()
                 .join(" "),
         )

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -39,29 +39,45 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let target = options.target;
 
     if options.no_binstall {
-        let target = match target {
-            Some(target) => target,
-            None => get_target_triple()?,
-        };
-
-        let crate_details = CrateDetails {
+        do_main_curl(
             crate_name,
             version,
             target,
-        };
-
-        if options.dry_run {
-            let shell_cmd = do_dry_run_curl(&crate_details);
-            println!("{}", shell_cmd);
-            return Ok(());
-        }
-
-        let stats_handle = report_stats_in_background(&crate_details);
-        install_crate_curl(&crate_details, options.fallback)?;
-        stats_handle.join().unwrap();
+            options.dry_run,
+            options.fallback,
+        )
     } else {
-        todo!()
+        Ok(())
     }
+}
+
+fn do_main_curl(
+    crate_name: String,
+    version: String,
+    target: Option<String>,
+    dry_run: bool,
+    fallback: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let target = match target {
+        Some(target) => target,
+        None => get_target_triple()?,
+    };
+
+    let crate_details = CrateDetails {
+        crate_name,
+        version,
+        target,
+    };
+
+    if dry_run {
+        let shell_cmd = do_dry_run_curl(&crate_details);
+        println!("{}", shell_cmd);
+        return Ok(());
+    }
+
+    let stats_handle = report_stats_in_background(&crate_details);
+    install_crate_curl(&crate_details, fallback)?;
+    stats_handle.join().unwrap();
 
     Ok(())
 }

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -31,29 +31,28 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let crate_name = options
         .crate_name
         .ok_or(InstallError::MissingCrateNameArgument(args::USAGE))?;
-    let version = match options.version {
-        Some(version) => version,
-        None => get_latest_version(&crate_name)?,
-    };
 
+    let version = options.version;
     let target = options.target;
 
-    if options.no_binstall {
-        do_main_curl(
-            crate_name,
-            version,
-            target,
-            options.dry_run,
-            options.fallback,
-        )
+    let f = if options.no_binstall {
+        do_main_curl
     } else {
-        Ok(())
-    }
+        do_main_binstall
+    };
+
+    f(
+        crate_name,
+        version,
+        target,
+        options.dry_run,
+        options.fallback,
+    )
 }
 
 fn do_main_curl(
     crate_name: String,
-    version: String,
+    version: Option<String>,
     target: Option<String>,
     dry_run: bool,
     fallback: bool,
@@ -61,6 +60,11 @@ fn do_main_curl(
     let target = match target {
         Some(target) => target,
         None => get_target_triple()?,
+    };
+
+    let version = match version {
+        Some(version) => version,
+        None => get_latest_version(&crate_name)?,
     };
 
     let crate_details = CrateDetails {
@@ -80,4 +84,117 @@ fn do_main_curl(
     stats_handle.join().unwrap();
 
     Ok(())
+}
+
+struct Crate {
+    name: String,
+    version: Option<String>,
+}
+
+impl Crate {
+    fn into_arg(self) -> String {
+        let mut arg = self.name;
+
+        if let Some(version) = self.version {
+            arg.push('@');
+            arg += version.as_str();
+        }
+
+        arg
+    }
+}
+
+fn do_main_binstall(
+    crate_name: String,
+    version: Option<String>,
+    target: Option<String>,
+    dry_run: bool,
+    fallback: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let is_binstall_compatible = get_cargo_binstall_version()
+        .map(
+            |binstall_version| match binstall_version.splitn(3, '.').collect::<Vec<_>>()[..] {
+                [major, minor, _] => {
+                    // If >=1.0.0
+                    major != "0"
+                            // Or >=0.17.0
+                            || minor
+                                .parse::<u64>()
+                                .map(|minor| minor >= 17)
+                                .unwrap_or(false)
+                }
+                _ => false,
+            },
+        )
+        .unwrap_or(false);
+
+    if !is_binstall_compatible {
+        do_main_curl("cargo-binstall".to_string(), None, None, dry_run, fallback)?;
+
+        if !dry_run {
+            println!("Bootstrap cargo-binstall itself to update $CARGO_HOME/.crates.toml");
+            do_install_binstall(
+                vec![Crate {
+                    name: "cargo-binstall".to_string(),
+                    version: None,
+                }],
+                None,
+                false,
+                true,
+            )?;
+        } else {
+            return Ok(());
+        }
+    }
+
+    do_install_binstall(
+        vec![Crate {
+            name: crate_name,
+            version,
+        }],
+        target,
+        dry_run,
+        false,
+    )
+}
+
+fn do_install_binstall(
+    crates: Vec<Crate>,
+    target: Option<String>,
+    dry_run: bool,
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let mut cmd = std::process::Command::new("cargo");
+
+    cmd.arg("binstall").arg("--no-confirm");
+
+    if let Some(target) = target {
+        cmd.arg("--targets").arg(target);
+    }
+
+    if force {
+        cmd.arg("--force");
+    }
+
+    if dry_run {
+        cmd.arg("--dry-run");
+    }
+
+    cmd.args(crates.into_iter().map(Crate::into_arg));
+
+    let status = cmd.status()?;
+
+    if !status.success() {
+        Err(format!(
+            "`{} {}` failed with {status}",
+            cmd.get_program().to_string_lossy().into_owned(),
+            cmd.get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join(" "),
+        )
+        .into())
+    } else {
+        Ok(())
+    }
 }

--- a/cargo-quickinstall/tests/integration_tests.rs
+++ b/cargo-quickinstall/tests/integration_tests.rs
@@ -19,7 +19,7 @@ fn quickinstall_for_ripgrep() {
     };
     let do_not_fallback_on_cargo_install = false;
 
-    let result = install_crate(&crate_details, do_not_fallback_on_cargo_install);
+    let result = install_crate_curl(&crate_details, do_not_fallback_on_cargo_install);
 
     assert!(result.is_ok());
 }
@@ -36,7 +36,7 @@ fn do_dry_run_for_ripgrep() {
         target: "x86_64-unknown-linux-gnu".to_string(),
     };
 
-    let result = do_dry_run(&crate_details);
+    let result = do_dry_run_curl(&crate_details);
 
     let expected_prefix = r#""curl" "--user-agent" "cargo-quickinstall client (alsuren@gmail.com)" "--location" "--silent" "--show-error" "--fail" "https://github.com/cargo-bins/cargo-quickinstall/releases/download/ripgrep-13.0.0-x86_64-unknown-linux-gnu/ripgrep-13.0.0-x86_64-unknown-linux-gnu.tar.gz" | "tar" "-xzvvf" "-" "-C""#;
     assert!(result.starts_with(expected_prefix));
@@ -51,7 +51,7 @@ fn do_dry_run_for_nonexistent_package() {
         target: "unknown".to_string(),
     };
 
-    let result = do_dry_run(&crate_details);
+    let result = do_dry_run_curl(&crate_details);
 
     let expected = r#""cargo" "install" "nonexisting_crate_12345" "--version" "99""#;
     assert_eq!(expected, &result);


### PR DESCRIPTION
Fixed #71