### PR TITLE
Tweak `profile.release` for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,10 @@
 members = [
     "cargo-quickinstall",
 ]
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = "symbols"


### PR DESCRIPTION
On my M1, this increase the compilation time from 1.15s => 3.15s, but reduce the size from 792K => 412K.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>