### PR TITLE
Fix `install_crate_curl`: Call `report_stats_in_background` to report stats

### DIFF
--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -109,7 +109,7 @@ pub fn get_target_triple() -> Result<String, InstallError> {
     .into())
 }
 
-pub fn report_stats_in_background(details: &CrateDetails) -> std::thread::JoinHandle<()> {
+pub fn report_stats_in_background(details: &CrateDetails) {
     let tarball_name = format!(
         "{}-{}-{}.tar.gz",
         details.crate_name, details.version, details.target
@@ -119,10 +119,12 @@ pub fn report_stats_in_background(details: &CrateDetails) -> std::thread::JoinHa
         "https://warehouse-clerk-tmp.vercel.app/api/crate/{}",
         tarball_name
     );
-    std::thread::spawn(move || {
-        // warehouse-clerk is known to return 404. This is fine. We only use it for stats gathering.
-        curl_head(&stats_url).unwrap_or_default();
-    })
+
+    // Simply spawn the curl command to report stat.
+    //
+    // It's ok for it to fail and we would let the init process reap
+    // the `curl` process.
+    prepare_curl_head_cmd(&stats_url).spawn().ok();
 }
 
 pub fn do_dry_run_curl(crate_details: &CrateDetails) -> String {

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -185,17 +185,23 @@ fn untar(tarball: Vec<u8>) -> Result<String, InstallError> {
     Ok(stdout + &stderr)
 }
 
-fn curl_head(url: &str) -> Result<Vec<u8>, InstallError> {
-    let output = std::process::Command::new("curl")
-        .arg("--user-agent")
+fn prepare_curl_head_cmd(url: &str) -> std::process::Command {
+    let mut cmd = std::process::Command::new("curl");
+
+    cmd.arg("--user-agent")
         .arg("cargo-quickinstall client (alsuren@gmail.com)")
         .arg("--head")
         .arg("--silent")
         .arg("--show-error")
         .arg("--fail")
         .arg("--location")
-        .arg(url)
-        .output()?;
+        .arg(url);
+
+    cmd
+}
+
+fn curl_head(url: &str) -> Result<Vec<u8>, InstallError> {
+    let output = prepare_curl_head_cmd(url).output()?;
     if !output.status.success() {
         let stdout = String::from_utf8(output.stdout).unwrap();
         let stderr = String::from_utf8(output.stderr).unwrap();

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -49,15 +49,18 @@ pub fn install_crate_curl(details: &CrateDetails, fallback: bool) -> Result<(), 
             Ok(())
         }
         Err(err) if err.is_curl_404() => {
-            if !fallback {
-                return Err(InstallError::NoFallback(details.clone()));
-            }
-
             println!(
                 "Could not find a pre-built package for {} {} on {}.",
                 details.crate_name, details.version, details.target
             );
             println!("We have reported your installation request, so it should be built soon.");
+
+            report_stats_in_background(details);
+
+            if !fallback {
+                return Err(InstallError::NoFallback(details.clone()));
+            }
+
             println!("Falling back to `cargo install`.");
 
             let status = prepare_cargo_install_cmd(details).status()?;

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -110,14 +110,9 @@ pub fn get_target_triple() -> Result<String, InstallError> {
 }
 
 pub fn report_stats_in_background(details: &CrateDetails) {
-    let tarball_name = format!(
-        "{}-{}-{}.tar.gz",
-        details.crate_name, details.version, details.target
-    );
-
     let stats_url = format!(
-        "https://warehouse-clerk-tmp.vercel.app/api/crate/{}",
-        tarball_name
+        "https://warehouse-clerk-tmp.vercel.app/api/crate/{}-{}-{}.tar.gz",
+        details.crate_name, details.version, details.target
     );
 
     // Simply spawn the curl command to report stat.


### PR DESCRIPTION
And optimize `report_stats_in_background`: Avoid the expensive `thread::spawn` and optimize out one `String` creation.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>