### PR TITLE
Tweak release build settings to reduce size and compilation time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,8 @@
 members = [
     "cargo-quickinstall",
 ]
+
+[profile.release]
+opt-level = "z"
+panic = "abort"
+strip = "symbols"


### PR DESCRIPTION
Supersedes #118 

This PR is able to get both the binary size reduction as well as reduction in compilation time by using `-Oz`, stripping debug info and abort on panic.

It was able to reduce size from 700K => 476K while reducing compilation time on my M1 from 1s => 0.75s.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>