### PR TITLE
milo/support aarch64 unknown gnu

### DIFF
--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -23,6 +23,8 @@ jobs:
             os: ubuntu-20.04
           - target_arch: x86_64-unknown-linux-musl
             os: ubuntu-20.04
+          - target_arch: aarch64-unknown-linux-gnu
+            os: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/build-version.sh
+++ b/build-version.sh
@@ -30,6 +30,20 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"
     CRATES2_JSON_PATH="${TEMPDIR}/cargo/.crates2.json"
+elif [ "$TARGET_ARCH" == "aarch64-unknown-linux-gnu" ]; then
+    mkdir -p zigfolder
+    curl "$(curl -q https://ziglang.org/download/index.json | jq 'to_entries | map([.key, .value])[1][1]["x86_64-linux"] | .tarball' | sed -e 's/^"//' -e 's/"$//')" | tar -xJ -C zigfolder --strip-components 1
+
+    export PATH="$PWD/zigfolder:$PATH"
+    rustup target add "$TARGET_ARCH"
+    if ! [ -f "$HOME/.cargo/config" ]; then
+        echo "[target.aarch64-unknown-linux-gnu]" >>~/.cargo/config
+        echo "linker = \"$PWD/zig-aarch64.sh\"" >>~/.cargo/config
+    fi
+
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 CC=./zig-aarch64.sh cargo install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
+    CARGO_BIN_DIR=~/.cargo/bin
+    CRATES2_JSON_PATH=~/.cargo/.crates2.json
 else
     rustup target add "$TARGET_ARCH"
     CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 cargo install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"

--- a/trigger-package-build.sh
+++ b/trigger-package-build.sh
@@ -14,6 +14,8 @@ get_build_os() {
         echo "ubuntu-20.04"
     elif [[ "$1" == "x86_64-pc-windows-msvc" ]]; then
         echo "windows-latest"
+    elif [[ "$1" == "aarch64-unknown-linux-gnu" ]]; then
+        echo "ubuntu-20.04"
     else
         echo "Unrecognised build OS: $1"
         exit 1
@@ -46,7 +48,7 @@ main() {
         git config user.name "trigger-package-build.sh"
     fi
 
-    TARGET_ARCHES="${TARGET_ARCHES:-${TARGET_ARCH:-x86_64-pc-windows-msvc x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-linux-gnu x86_64-unknown-linux-musl}}"
+    TARGET_ARCHES="${TARGET_ARCHES:-${TARGET_ARCH:-x86_64-pc-windows-msvc x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-linux-gnu x86_64-unknown-linux-musl aarch64-unknown-linux-gnu}}"
 
     if [ ! -d "${TEMPDIR:-}" ]; then
         TEMPDIR="$(mktemp -d)"

--- a/zig-aarch64.sh
+++ b/zig-aarch64.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# shellcheck disable=SC2068
+exec zig cc -target aarch64-linux-gnu $@


### PR DESCRIPTION
This allows `cargo-quickbuild` to build for `aarch64-unknown-linux-gnu`.