### PR TITLE
Fix `test_get_latest_version`: Use `git-tag` instead of `git-describe`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,8 @@ jobs:
       - name: Fetch source
         uses: actions/checkout@v3
 
-      - name: Fetch tags and origin/main required for testing
-        run: |
-          git fetch --tags
-          git fetch origin main
+      - name: Fetch tags required for testing
+        run: git fetch --tags
 
       - name: Run test
         run: cargo test

--- a/cargo-quickinstall/tests/integration_tests.rs
+++ b/cargo-quickinstall/tests/integration_tests.rs
@@ -72,10 +72,10 @@ fn do_dry_run_for_nonexistent_package() {
 fn test_get_latest_version() {
     let stdout = std::process::Command::new("git")
         .args([
-            "describe",
-            "--match",
+            "tag",
+            "--list",
+            "--sort=-version:refname",
             "cargo-quickinstall-v*",
-            "origin/main",
         ])
         .output_checked_status()
         .unwrap()
@@ -84,11 +84,12 @@ fn test_get_latest_version() {
 
     let version = stdout
         .trim()
+        .lines()
+        .next()
+        .unwrap()
+        .trim()
         .strip_prefix("cargo-quickinstall-v")
-        .unwrap()
-        .split_once('-')
-        .unwrap()
-        .0;
+        .unwrap();
 
     assert_eq!(get_latest_version("cargo-quickinstall").unwrap(), version);
 }


### PR DESCRIPTION
The former works more reliably, including on a shallow repository with tags fetched.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>