### PR TITLE
Download binstall from upstream if possible and add e2etest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,24 @@ jobs:
 
       - name: Run test
         run: cargo test
+
+  e2etest:
+    runs-on: ubuntu-latest
+
+    steps:
+      # TODO: actions/cache@v2?
+      - name: Fetch source
+        uses: actions/checkout@v3
+
+      - name: Test dry-run
+        run: cargo r -- --dry-run cargo-quickinstall
+
+      - name: Test installing and using binstall
+        run: |
+          cargo r -- cargo-quickinstall
+          cargo quickinstall -V
+
+      - name: Test using binstall with it already installed
+        run: |
+          cargo r -- cargo-quickinstall
+          cargo quickinstall -V

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,5 +66,5 @@ jobs:
 
       - name: Test using binstall with it already installed
         run: |
-          cargo r -- --force cargo-quickinstall
+          cargo r -- cargo-quickinstall
           cargo quickinstall -V

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,5 +66,5 @@ jobs:
 
       - name: Test using binstall with it already installed
         run: |
-          cargo r -- cargo-quickinstall
+          cargo r -- --force cargo-quickinstall
           cargo quickinstall -V

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,13 @@ jobs:
         run: cargo test
 
   e2etest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+          - os: macos-latest
+          - os: ubuntu-latest
 
     steps:
       # TODO: actions/cache@v2?

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,19 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "cargo-quickinstall"
 version = "0.2.7"
 dependencies = [
  "home",
  "mktemp",
  "pico-args",
+ "tempfile",
  "tinyjson",
 ]
 
@@ -17,6 +24,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "getrandom"
@@ -39,6 +55,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +83,38 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "tinyjson"

--- a/cargo-quickinstall/Cargo.toml
+++ b/cargo-quickinstall/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/cargo-bins/cargo-quickinstall"
 tinyjson = "2"
 home = "0.5.4"
 pico-args = { version = "0.5.0", features = ["eq-separator"] }
+tempfile = "3.3.0"
 
 [dev-dependencies]
 mktemp = "0.5.0"

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -214,12 +214,10 @@ fn format_curl_and_untar_cmd(url: &str, bin_dir: &Path) -> String {
 }
 
 pub fn do_dry_run_curl(crate_details: &CrateDetails) -> Result<String, InstallError> {
-    let crate_download_url = format!(
-        "https://github.com/cargo-bins/cargo-quickinstall/releases/download/\
-                 {crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz",
-        crate_name = crate_details.crate_name,
-        version = crate_details.version,
-        target = crate_details.target
+    let crate_download_url = get_quickinstall_download_url(
+        &crate_details.crate_name,
+        &crate_details.version,
+        &crate_details.target,
     );
     if curl_head(&crate_download_url).is_ok() {
         let cargo_bin_dir = get_cargo_bin_dir()?;
@@ -308,16 +306,18 @@ pub fn curl_json(url: &str) -> Result<JsonValue, InstallError> {
         })
 }
 
+fn get_quickinstall_download_url(crate_name: &str, version: &str, target: &str) -> String {
+    format!(
+        "https://github.com/cargo-bins/cargo-quickinstall/releases/download/{crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz",
+    )
+}
+
 fn download_tarball(
     crate_name: &str,
     version: &str,
     target: &str,
 ) -> Result<ChildWithCommand, InstallError> {
-    let github_url = format!(
-        "https://github.com/cargo-bins/cargo-quickinstall/releases/download/{crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz",
-        crate_name=crate_name, version=version, target=target,
-    );
-    curl(&github_url)
+    curl(&get_quickinstall_download_url(crate_name, version, target))
 }
 
 fn prepare_curl_cmd() -> std::process::Command {

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -3,7 +3,7 @@
 //! Tries to install pre-built binary crates whenever possibles.  Falls back to
 //! `cargo install` otherwise.
 
-use std::{path::Path, process};
+use std::{fs::File, path::Path, process};
 use tinyjson::JsonValue;
 
 pub mod install_error;
@@ -206,6 +206,16 @@ fn curl(url: &str) -> Result<ChildWithCommand, InstallError> {
         .stdout(process::Stdio::piped())
         .stderr(process::Stdio::piped());
     cmd.spawn_with_cmd()
+}
+
+fn curl_file(url: &str, file: File) -> Result<(), InstallError> {
+    prepare_curl_bytes_cmd(url)
+        .stdin(process::Stdio::null())
+        .stdout(file)
+        .stderr(process::Stdio::piped())
+        .output_checked_status()?;
+
+    Ok(())
 }
 
 fn curl_bytes(url: &str) -> Result<Vec<u8>, InstallError> {

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -37,9 +37,9 @@ pub struct CrateDetails {
 /// Return (archive_format, url)
 fn get_binstall_upstream_url(target: &str) -> (&'static str, String) {
     let archive_format = if target.contains("linux") {
-        ".tgz"
+        "tgz"
     } else {
-        ".zip"
+        "zip"
     };
     let url = format!("https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-{target}.{archive_format}");
 
@@ -50,12 +50,12 @@ fn get_binstall_upstream_url(target: &str) -> (&'static str, String) {
 pub fn download_and_install_binstall_from_upstream(target: &str) -> Result<(), InstallError> {
     let (archive_format, url) = get_binstall_upstream_url(target);
 
-    if archive_format == ".tgz" {
+    if archive_format == "tgz" {
         untar(curl(&url)?)?;
 
         Ok(())
     } else {
-        assert_eq!(archive_format, ".zip");
+        assert_eq!(archive_format, "zip");
 
         let (zip_file, zip_file_temp_path) = NamedTempFile::new()?.into_parts();
 

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -114,11 +114,7 @@ pub fn install_crate_curl(details: &CrateDetails, fallback: bool) -> Result<(), 
     // error when spawning curl.
     //
     // untar will wait on curl, so it will include the 404 error.
-    match untar(download_tarball(
-        &details.crate_name,
-        &details.version,
-        &details.target,
-    )?) {
+    match untar(download_tarball(details)?) {
         Ok(tar_output) => {
             // tar output contains its own newline.
             print!(
@@ -214,11 +210,7 @@ fn format_curl_and_untar_cmd(url: &str, bin_dir: &Path) -> String {
 }
 
 pub fn do_dry_run_curl(crate_details: &CrateDetails) -> Result<String, InstallError> {
-    let crate_download_url = get_quickinstall_download_url(
-        &crate_details.crate_name,
-        &crate_details.version,
-        &crate_details.target,
-    );
+    let crate_download_url = get_quickinstall_download_url(crate_details);
     if curl_head(&crate_download_url).is_ok() {
         let cargo_bin_dir = get_cargo_bin_dir()?;
 
@@ -306,18 +298,20 @@ pub fn curl_json(url: &str) -> Result<JsonValue, InstallError> {
         })
 }
 
-fn get_quickinstall_download_url(crate_name: &str, version: &str, target: &str) -> String {
+fn get_quickinstall_download_url(
+    CrateDetails {
+        crate_name,
+        version,
+        target,
+    }: &CrateDetails,
+) -> String {
     format!(
         "https://github.com/cargo-bins/cargo-quickinstall/releases/download/{crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz",
     )
 }
 
-fn download_tarball(
-    crate_name: &str,
-    version: &str,
-    target: &str,
-) -> Result<ChildWithCommand, InstallError> {
-    curl(&get_quickinstall_download_url(crate_name, version, target))
+fn download_tarball(crate_details: &CrateDetails) -> Result<ChildWithCommand, InstallError> {
+    curl(&get_quickinstall_download_url(crate_details))
 }
 
 fn prepare_curl_cmd() -> std::process::Command {

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -75,11 +75,7 @@ pub fn do_dry_run_download_and_install_binstall_from_upstream(
     let cargo_bin_dir = get_cargo_bin_dir()?;
 
     if archive_format == ".tgz" {
-        Ok(format!(
-            "{curl_cmd} | {untar_cmd}",
-            curl_cmd = prepare_curl_bytes_cmd(&url).formattable(),
-            untar_cmd = prepare_untar_cmd(&cargo_bin_dir).formattable(),
-        ))
+        Ok(format_curl_and_untar_cmd(&url, &cargo_bin_dir))
     } else {
         Ok(format!(
             "temp=\"$(mktemp)\"\n{curl_cmd} >\"$temp\"\nunzip \"$temp\" -d {extdir}",
@@ -209,6 +205,14 @@ pub fn report_stats_in_background(details: &CrateDetails) {
     prepare_curl_head_cmd(&stats_url).spawn().ok();
 }
 
+fn format_curl_and_untar_cmd(url: &str, bin_dir: &Path) -> String {
+    format!(
+        "{curl_cmd} | {untar_cmd}",
+        curl_cmd = prepare_curl_bytes_cmd(url).formattable(),
+        untar_cmd = prepare_untar_cmd(bin_dir).formattable(),
+    )
+}
+
 pub fn do_dry_run_curl(crate_details: &CrateDetails) -> Result<String, InstallError> {
     let crate_download_url = format!(
         "https://github.com/cargo-bins/cargo-quickinstall/releases/download/\
@@ -220,10 +224,9 @@ pub fn do_dry_run_curl(crate_details: &CrateDetails) -> Result<String, InstallEr
     if curl_head(&crate_download_url).is_ok() {
         let cargo_bin_dir = get_cargo_bin_dir()?;
 
-        Ok(format!(
-            "{curl_cmd} | {untar_cmd}",
-            curl_cmd = prepare_curl_bytes_cmd(&crate_download_url).formattable(),
-            untar_cmd = prepare_untar_cmd(&cargo_bin_dir).formattable(),
+        Ok(format_curl_and_untar_cmd(
+            &crate_download_url,
+            &cargo_bin_dir,
         ))
     } else {
         let cargo_install_cmd = prepare_cargo_install_cmd(crate_details);

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -128,7 +128,7 @@ fn do_main_binstall(
         .unwrap_or(false);
 
     if !is_binstall_compatible {
-        do_main_curl("cargo-binstall".to_string(), None, None, dry_run, false)?;
+        download_and_install_binstall(dry_run)?;
 
         if !dry_run {
             println!(
@@ -155,6 +155,35 @@ fn do_main_binstall(
         target,
         BinstallMode::Regular { dry_run },
     )
+}
+
+fn download_and_install_binstall(
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let target = get_target_triple()?;
+
+    if dry_run {
+        let shell_cmd = do_dry_run_download_and_install_binstall_from_upstream(&target)?;
+        println!("{shell_cmd}");
+        return Ok(());
+    }
+
+    match download_and_install_binstall_from_upstream(&target) {
+        Err(err) if err.is_curl_404() => {
+            println!(
+                "Failed to install cargo-binstall from upstream, fallback to quickinstall: {err}"
+            );
+
+            do_main_curl(
+                "cargo-binstall".to_string(),
+                None,
+                Some(target),
+                false,
+                false,
+            )
+        }
+        res => res.map_err(From::from),
+    }
 }
 
 enum BinstallMode {

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -130,7 +130,12 @@ fn do_main_binstall(
     if !is_binstall_compatible {
         download_and_install_binstall(dry_run)?;
 
-        if !dry_run {
+        if dry_run {
+            return Ok(());
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
             println!(
                 "Bootstrapping cargo-binstall with itself to make `cargo uninstall ` work properly"
             );
@@ -142,8 +147,6 @@ fn do_main_binstall(
                 None,
                 BinstallMode::Bootstrapping,
             )?;
-        } else {
-            return Ok(());
         }
     }
 


### PR DESCRIPTION
* Add new dep tempfile v3.3.0
* Impl new fn `curl_file`
* Install binstall from upstream if possible
* Add e2etest for installing and using cargo-binstall
* Refactor: Extract new fn `format_curl_and_untar_cmd`
* Refactor: Extract new fn `get_quickinstall_download_url`
* Runs e2e tests on windows, macos and ubuntu
* Disable bootstraping binstall on windows

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>