### PR TITLE
Add `cargo-auditable` to `popular-crates.txt`

### DIFF
--- a/popular-crates.txt
+++ b/popular-crates.txt
@@ -20,6 +20,7 @@
 # The first empty line is important. I can't remember why.
 
 cargo-quickinstall
+cargo-auditable
 sensei
 ripgrep
 cargo-make


### PR DESCRIPTION
I'd like quickinstall to provide pre-built artifacts for `cargo-auditable` so that we can use it in cargo-binstall and cargo-quickinstall.