### PR TITLE
Use `cargo-auditable` to build the binaries

### DIFF
--- a/.github/workflows/build-package.yml.template
+++ b/.github/workflows/build-package.yml.template
@@ -30,6 +30,10 @@ jobs:
           ref: $BRANCH
           path: cargo-quickinstall
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-auditable
+
       - name: build package
         env:
           TEMPDIR: ${{github.workspace}}/built.d

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -27,6 +27,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-auditable
+
       - name: Build Thyself
         env:
           TARGET_ARCH: ${{ matrix.target_arch }}

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,14 +25,14 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf - -C $CARGO_HOME/bin; cargo binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION --path ."
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf - -C $CARGO_HOME/bin; cargo binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"
     CRATES2_JSON_PATH="${TEMPDIR}/cargo/.crates2.json"
 else
     rustup target add "$TARGET_ARCH"
-    CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 cargo auditable install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH" --path .
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 cargo auditable install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
 
     CARGO_BIN_DIR=~/.cargo/bin
     CRATES2_JSON_PATH=~/.cargo/.crates2.json

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; ls \$CARGO_HOME; rm \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; ls -lsha \$CARGO_HOME; rm \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"

--- a/build-version.sh
+++ b/build-version.sh
@@ -32,7 +32,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     CRATES2_JSON_PATH="${TEMPDIR}/cargo/.crates2.json"
 else
     rustup target add "$TARGET_ARCH"
-    CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 cargo install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 cargo auditable install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH" --path .
 
     CARGO_BIN_DIR=~/.cargo/bin
     CRATES2_JSON_PATH=~/.cargo/.crates2.json

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf - -C $CARGO_HOME/bin; cargo binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION --path ."
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"

--- a/build-version.sh
+++ b/build-version.sh
@@ -32,7 +32,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     CRATES2_JSON_PATH="${TEMPDIR}/cargo/.crates2.json"
 else
     rustup target add "$TARGET_ARCH"
-    rm ~/.cargo/.crates2.json
+    rm -f ~/.cargo/.crates2.json
     CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 cargo auditable install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
 
     CARGO_BIN_DIR=~/.cargo/bin

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf - -C $CARGO_HOME/bin; cargo binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf - -C \"\$CARGO_HOME/bin\"; cargo binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; ls -lsha \$CARGO_HOME; rm \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; rm -f \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,13 +25,14 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; rm \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"
     CRATES2_JSON_PATH="${TEMPDIR}/cargo/.crates2.json"
 else
     rustup target add "$TARGET_ARCH"
+    rm ~/.cargo/.crates2.json
     CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 cargo auditable install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH"
 
     CARGO_BIN_DIR=~/.cargo/bin

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; rm \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall -y cargo-auditable; ls \$CARGO_HOME; rm \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"

--- a/build-version.sh
+++ b/build-version.sh
@@ -25,7 +25,7 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf - -C \"\$CARGO_HOME/bin\"; cargo binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "apk add build-base; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | tar -xzvvf -; ./cargo-binstall binstall cargo-auditable; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION"
     podman cp official-alpine-rust:/usr/local/cargo "${TEMPDIR}/"
 
     CARGO_BIN_DIR="${TEMPDIR}/cargo/bin"


### PR DESCRIPTION
Fixed #133

so that it contains version information that can be extracted by tools such as `cargo-audit` to check for vulnerabilities.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>