### PR TITLE
Fixes for my release feedback notes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,21 +61,21 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Test dry-run
-        run: cargo r -- --dry-run cargo-quickinstall
+        run: cargo run -- --dry-run cargo-quickinstall
 
       - name: Test installing and using binstall
         run: |
-          cargo r -- cargo-quickinstall
+          cargo run -- cargo-quickinstall
           cargo quickinstall -V
 
       - name: Test using binstall with it already installed
         run: |
-          cargo r -- cargo-quickinstall
+          cargo run -- cargo-quickinstall
           cargo quickinstall -V
 
       - name: Test batch installation with binstall
         run: |
-          cargo r -- cargo-quickinstall cargo-nextest
+          cargo run -- cargo-quickinstall cargo-nextest
           cargo quickinstall -V
           cargo nextest -V
 
@@ -85,13 +85,12 @@ jobs:
           echo Rm all binaries installed but do not update manifests,
           echo so that binstall will think they are installed.
           rm $(which cargo-quickinstall) $(which cargo-nextest)
-          cargo r -- --force cargo-quickinstall cargo-nextest
+          cargo run -- --force cargo-quickinstall cargo-nextest
           cargo quickinstall -V
           cargo nextest -V
 
       - name: Test batch installation with curl
         run: |
-          cargo r -- --no-binstall cargo-quickinstall cargo-nextest
+          cargo run -- --no-binstall cargo-quickinstall cargo-nextest
           cargo quickinstall -V
           cargo nextest -V
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Test batch installation with binstall
         run: |
-          cargo run -- cargo-quickinstall cargo-nextest
+          cargo run -- cargo-quickinstall cargo-nextest@0.9.28
           cargo quickinstall -V
           cargo nextest -V
 
@@ -84,13 +84,13 @@ jobs:
         run: |
           echo Rm all binaries installed but do not update manifests,
           echo so that binstall will think they are installed.
-          rm $(which cargo-quickinstall) $(which cargo-nextest)
-          cargo run -- --force cargo-quickinstall cargo-nextest
+          rm $(which cargo-quickinstall) $(which cargo-nextest@0.9.28)
+          cargo run -- --force cargo-quickinstall cargo-nextest@0.9.28
           cargo quickinstall -V
           cargo nextest -V
 
       - name: Test batch installation with curl
         run: |
-          cargo run -- --no-binstall cargo-quickinstall cargo-nextest
+          cargo run -- --no-binstall cargo-quickinstall cargo-nextest@0.9.28
           cargo quickinstall -V
           cargo nextest -V

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Test batch installation with binstall
         run: |
-          cargo run -- cargo-quickinstall cargo-nextest
+          cargo run -- --try-upstream cargo-quickinstall cargo-nextest
           cargo quickinstall -V
           cargo nextest -V
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Test batch installation with binstall
         run: |
-          cargo run -- --try-upstream cargo-quickinstall cargo-nextest
+          cargo run -- cargo-quickinstall cargo-nextest
           cargo quickinstall -V
           cargo nextest -V
 

--- a/cargo-quickinstall/src/args.rs
+++ b/cargo-quickinstall/src/args.rs
@@ -25,7 +25,10 @@ OPTIONS:
         --try-upstream              Try looking for official builds from the upstream maintainers.
                                     This takes a few extra seconds.
         --no-fallback               Don't fall back to `cargo install`
-        --no-binstall               Don't use `cargo binstall` to install packages.
+        --no-binstall               Don't use `cargo binstall` to install packages. `cargo-binstall`
+                                    sets metadata required for `cargo uninstall`, so only use
+                                    `--no-binstall` if you know you don't need to uninstall packages
+                                    (for example on CI builds).
         --dry-run                   Print the `curl | tar` command that would be run to fetch the binary
     -V, --print-version             Print version info and exit
     -h, --help                      Prints help information

--- a/cargo-quickinstall/src/args.rs
+++ b/cargo-quickinstall/src/args.rs
@@ -22,6 +22,8 @@ OPTIONS:
         --target <TRIPLE>           Install package for the target triple
         --force                     Install the <CRATES> even if they are already installed.
                                     Only effective when using `cargo-binstall`.
+        --try-upstream              Try looking for official builds from the upstream maintainers.
+                                    This takes a few extra seconds.
         --no-fallback               Don't fall back to `cargo install`
         --no-binstall               Don't use `cargo binstall` to install packages.
         --dry-run                   Print the `curl | tar` command that would be run to fetch the binary
@@ -33,6 +35,7 @@ OPTIONS:
 pub struct CliOptions {
     pub target: Option<String>,
     pub crate_names: Vec<Crate>,
+    pub try_upstream: bool,
     pub fallback: bool,
     pub force: bool,
     pub no_binstall: bool,
@@ -83,6 +86,7 @@ pub fn options_from_cli_args(
 
     let mut opts = CliOptions {
         target: args.opt_value_from_str("--target")?,
+        try_upstream: args.contains("--try-upstream"),
         fallback: !args.contains("--no-fallback"),
         force: args.contains("--force"),
         no_binstall: args.contains("--no-binstall"),

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -39,6 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 
     let args = Args {
         dry_run: options.dry_run,
+        try_upstream: options.try_upstream,
         fallback: options.fallback,
         force: options.force,
     };
@@ -55,6 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 #[derive(Default)]
 struct Args {
     dry_run: bool,
+    try_upstream: bool,
     fallback: bool,
     force: bool,
 }
@@ -225,6 +227,10 @@ fn do_install_binstall(
 
     if args.dry_run || matches!(mode, BinstallMode::PrintCmd) {
         cmd.arg("--dry-run");
+    }
+
+    if !args.try_upstream {
+        cmd.args(["--disable-strategies", "crate-meta-data"]);
     }
 
     if !args.fallback {

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -238,6 +238,8 @@ fn do_install_binstall(
         return Ok(());
     }
 
+    println!("Calling `cargo-binstall` to do the install");
+
     #[cfg(unix)]
     if !matches!(mode, BinstallMode::Bootstrapping) {
         return Err(std::os::unix::process::CommandExt::exec(&mut cmd).into());

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -1,4 +1,4 @@
-// cargo-quickinstall is optimised so that bootstrapping with
+// cargo-quickinstall is optimized so that bootstrapping with
 //
 //     cargo install cargo-quickinstall
 //
@@ -125,13 +125,13 @@ fn do_main_binstall(
         download_and_install_binstall(args.dry_run)?;
 
         if args.dry_run {
-            // cargo-binstall is not installeed, so we print out the cargo-binstall
+            // cargo-binstall is not installed, so we print out the cargo-binstall
             // cmd and exit.
             println!("cargo binstall --no-confirm --force cargo-binstall");
             return do_install_binstall(crates, target, BinstallMode::PrintCmd, args);
         } else {
             println!(
-                "Bootstrapping cargo-binstall with itself to make `cargo uninstall` work properly"
+                "Bootstrapping cargo-binstall with itself to make `cargo uninstall cargo-binstall` work properly"
             );
             do_install_binstall(
                 vec![Crate {

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -213,7 +213,7 @@ fn do_install_binstall(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let mut cmd = std::process::Command::new("cargo");
 
-    cmd.arg("binstall").arg("--no-confirm");
+    cmd.arg("binstall").arg("--no-confirm").arg("--no-symlinks");
 
     if let Some(target) = target {
         cmd.arg("--targets").arg(target);


### PR DESCRIPTION
This addresses all of the things I noticed in https://github.com/cargo-bins/cargo-quickinstall/issues/126

I decided to disable versioned symlinks because I find them annoying (they break my tab completion) and they're not something that `cargo install` does natively.

I decided to make searching for upstream packages opt-in because they're slow. Disabling that strategy brings the time for `cargo quickinstall bat --force` down from 10 seconds to 2 seconds. Still not as good as `cargo quickinstall bat --force --no-binstall` (1 second), but good enough for me. I also quite like the simplicity of the explanation "`cargo quickinstall $package` will always give you something equivalent to `cargo install $package`". I have allowed users to opt-in with the `--try-upstream` flag. There might be a better name than `--try-upstream`.

I decided that --no-binstall was a perfectly fine name for the command-line flag, so I kept it.