### PR TITLE
latest crate version might be yanked

### DIFF
--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -55,7 +55,7 @@ for CRATE in $POPULAR_CRATES; do
         mkdir -p "$RESPONSE_DIR"
         curl_slowly --location --fail "https://crates.io/api/v1/crates/${CRATE}" >"$RESPONSE_FILENAME"
     fi
-    VERSION=$(jq -r '.versions[0].num' "$RESPONSE_FILENAME")
+    VERSION=$(jq -r '[ .versions[] | select(.yanked == false) ][0].num' "$RESPONSE_FILENAME")
 
     if curl_slowly --location --fail -I --output /dev/null "https://github.com/cargo-bins/cargo-quickinstall/releases/download/${CRATE}-${VERSION}-${TARGET_ARCH}/${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz"; then
         echo "${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz already uploaded. Keep going." 1>&2


### PR DESCRIPTION
I was looking at aarch64 build failures and found https://github.com/cargo-bins/cargo-quickinstall/actions/runs/4037215661/jobs/6940354885#step:5:87

```
error: cannot install package `cargo-chef`, it has been yanked from registry `crates-io`
```