### PR TITLE
Optimize `get_latest_version`: Use field `.crate|.max_stable_version`

### DIFF
--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -168,9 +168,8 @@ pub fn get_latest_version(crate_name: &str) -> Result<String, InstallError> {
                 e
             }
         })?
-        .get_owned(&"versions")?
-        .get_owned(&0)?
-        .get_owned(&"num")?
+        .get_owned(&"crate")?
+        .get_owned(&"max_stable_version")?
         .try_into_string()
         .map_err(From::from)
 }


### PR DESCRIPTION
htttps://crates.io/api/v1/crates/$name contains a field `.crate|.max_stable_version`, which is the stable version listed on https://crates.io/crates/$name

https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/.E2.9C.94.20How.20to.20get.20the.20latest.20version.20from.20crates.2Eio.3F

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>