### PR TITLE
Add `supported-targets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ will print:
 
 Edit the command however you need, and paste it into your CI pipeline.
 
+## Supported targets
+
+Check [supported-targets](/supported-targets) for lists of targets quickinstall
+can build for.
+
 ## Limitations
 
 Non-default features are not supported.

--- a/supported-targets
+++ b/supported-targets
@@ -1,0 +1,1 @@
+x86_64-pc-windows-msvc x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-linux-gnu x86_64-unknown-linux-musl aarch64-unknown-linux-gnu

--- a/trigger-package-build.sh
+++ b/trigger-package-build.sh
@@ -48,7 +48,7 @@ main() {
         git config user.name "trigger-package-build.sh"
     fi
 
-    TARGET_ARCHES="${TARGET_ARCHES:-${TARGET_ARCH:-x86_64-pc-windows-msvc x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-linux-gnu x86_64-unknown-linux-musl aarch64-unknown-linux-gnu}}"
+    TARGET_ARCHES="${TARGET_ARCHES:-${TARGET_ARCH:-$(cat supported-targets)}}"
 
     if [ ! -d "${TEMPDIR:-}" ]; then
         TEMPDIR="$(mktemp -d)"


### PR DESCRIPTION
which lists all targets quickinstall can build for.

I intend to also use this in cargo-binstall to reduce amount of http requests sent to GitHub.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>