### PR TITLE
make cronjob still work when stats server is down

### DIFF
--- a/get-stats.sh
+++ b/get-stats.sh
@@ -15,7 +15,7 @@ curl \
     if [[ "${TARGET_ARCH:-}" != "" ]]; then
         jq -r 'keys | .[]' |
             (grep -F "${TARGET_ARCH:-}" || true) |
-            sed 's:/.*::'
+            sed 's:/.*::' || (echo "Invalid json from stats server. Probably rate limit error. Skipping for now." >&2)
     else
         jq '.'
     fi


### PR DESCRIPTION
> parse error: Invalid numeric literal at line 1, column 10

-- https://github.com/cargo-bins/cargo-quickinstall/actions/runs/4337401745/jobs/7573375129#step:3:78

The underlying error is `[ioredis] Unhandled error event: ReplyError: ERR max daily request limit exceeded. Limit: 10000, Usage: 10000. See https://docs.upstash.com/overall/databasetypes for details` but that's in the server logs at https://vercel.com/alsuren/warehouse-clerk-tmp/logs?page=3&timeline=past30Minutes&startDate=1678040918696&endDate=1678042718696&selectedLogId=1678041917367918720482439920&selectedLogTimestamp=1678041917367&forceEndDate=1678042132566 and I don't have a way to share that.

Hopefully when we rip out the vercel+redis stats server we can stop having this problem.