### PR TITLE
Fix bootstrapping `cargo-auditable` in x86_64-unknown-linux-musl

### DIFF
--- a/build-version.sh
+++ b/build-version.sh
@@ -31,7 +31,10 @@ if [ "$TARGET_ARCH" == "x86_64-unknown-linux-musl" ]; then
     # Compiling against musl libc is failing despite installing the musl-tools
     # deb.  Falling back to Rust's Alpine container whose default target
     # is x86_64-unknown-linux-musl.
-    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | gunzip -c | tar -xvvf -; ./cargo-binstall binstall -y cargo-auditable; rm -f \$CARGO_HOME/.crates.toml \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION --locked"
+    #
+    # Use --force to fix the build for cargo-auditable, where cargo-auditable is already
+    # present in the dest.
+    podman run --name=official-alpine-rust docker.io/library/rust:alpine sh -c "set -euxo pipefail; apk update && apk add build-base curl; curl --location --silent --show-error --fail https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$TARGET_ARCH.tgz | gunzip -c | tar -xvvf -; ./cargo-binstall binstall -y cargo-auditable; rm -f \$CARGO_HOME/.crates.toml \$CARGO_HOME/.crates2.json; CARGO_PROFILE_RELEASE_CODEGEN_UNITS=\"1\" CARGO_PROFILE_RELEASE_LTO=\"fat\" OPENSSL_STATIC=1 cargo auditable install $CRATE --version $VERSION --locked --force"
     podman cp official-alpine-rust:/usr/local/cargo/.crates2.json "${CARGO_ROOT}/"
     podman cp official-alpine-rust:/usr/local/cargo/bin "${CARGO_ROOT}/"
     podman rm -fv official-alpine-rust


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>