### PR TITLE
Improve cross-compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .idea
 .vagrant
+zigfolder

--- a/build-version.sh
+++ b/build-version.sh
@@ -50,13 +50,13 @@ elif [ "$TARGET_ARCH" == "aarch64-unknown-linux-gnu" ]; then
     export PATH="$PWD/zigfolder:$PATH"
     rustup target add "$TARGET_ARCH"
     if ! [ -f "$HOME/.cargo/config" ]; then
-        echo "[target.aarch64-unknown-linux-gnu]" >>~/.cargo/config
-        echo "linker = \"$PWD/zig-aarch64.sh\"" >>~/.cargo/config
+        echo "[target.${TARGET_ARCH}]" >>~/.cargo/config
+        echo "linker = \"$PWD/zig.sh\"" >>~/.cargo/config
     fi
 
     CARGO_ROOT=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-root')
 
-    CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 CC="$PWD/zig-aarch64.sh" cargo auditable install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH" --root "$CARGO_ROOT" --locked
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 CC="$PWD/zig.sh" cargo auditable install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH" --root "$CARGO_ROOT" --locked
 
     CARGO_BIN_DIR="${CARGO_ROOT}/bin"
     CRATES2_JSON_PATH="${CARGO_ROOT}/.crates2.json"

--- a/build-version.sh
+++ b/build-version.sh
@@ -35,7 +35,7 @@ install_zig_cc_and_config_to_use_it() {
         fi
 
         mkdir -p zigfolder
-        url="$(curl -q https://ziglang.org/download/index.json | jq "to_entries | map([.key, .value])[1][1][\"${arch}\"] | .tarball" | sed -e 's/^"//' -e 's/"$//')"
+        url="$(curl -q https://ziglang.org/download/index.json | jq -r "to_entries | map([.key, .value])[1][1][\"${arch}\"] | .tarball")"
         curl "$url" | tar -xJ -C zigfolder --strip-components 1
     fi
 

--- a/build-version.sh
+++ b/build-version.sh
@@ -29,6 +29,9 @@ install_zig_cc_and_config_to_use_it() {
 
     export CC="$PWD/zig.sh"
     export RUSTFLAGS="-C linker=$PWD/zig.sh"
+    # Use our own pkg-config that fails for any input, since we cannot use
+    # locally installed lib in cross-compilation.
+    export PKG_CONFIG="$PWD/pkg-config-cross.sh"
 }
 
 REPO="$(./get-repo.sh)"
@@ -50,7 +53,14 @@ fi
 
 rustup target add "$TARGET_ARCH"
 CARGO_ROOT=$(mktemp -d 2>/dev/null || mktemp -d -t 'cargo-root')
-CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" CARGO_PROFILE_RELEASE_LTO="fat" OPENSSL_STATIC=1 cargo auditable install "$CRATE" --version "$VERSION" --target "$TARGET_ARCH" --root "$CARGO_ROOT" --locked
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS="1" \
+    CARGO_PROFILE_RELEASE_LTO="fat" \
+    OPENSSL_STATIC=1 \
+    cargo auditable install "$CRATE" \
+    --version "$VERSION" \
+    --target "$TARGET_ARCH" \
+    --root "$CARGO_ROOT" \
+    --locked
 
 CARGO_BIN_DIR="${CARGO_ROOT}/bin"
 CRATES2_JSON_PATH="${CARGO_ROOT}/.crates2.json"

--- a/pkg-config-cross.sh
+++ b/pkg-config-cross.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euxo pipefail
+
+echo "$0 is invoked with args" "${@:-}" >&2
+echo Since we are doing cross compilation, we cannot use any locally installed lib >&2
+echo Return 1 to signal error >&2
+
+exit 1

--- a/zig-aarch64.sh
+++ b/zig-aarch64.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# shellcheck disable=SC2068
-exec zig cc -target aarch64-linux-gnu $@

--- a/zig.sh
+++ b/zig.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -euxo pipefail
 
-zigfolder="$(dirname "$0")/zigfolder"
-
 if [ "${TARGET_ARCH?}" = "aarch64-unknown-linux-gnu" ]; then
     TARGET_ARG="-target aarch64-linux-gnu"
+elif [ "${TARGET_ARCH?}" = "x86_64-unknown-linux-musl" ]; then
+    TARGET_ARG="-target x86_64-linux-musl"
 else
     echo "Unsupported target ${TARGET_ARCH?}" >&2
     exit 1
 fi
 
 # shellcheck disable=SC2068,2086
-exec "${zigfolder}/zig" cc $TARGET_ARG $@
+exec cargo-zigbuild zig cc -- $TARGET_ARG $@

--- a/zig.sh
+++ b/zig.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 set -euxo pipefail
 
+zigfolder="$(dirname "$0")/zigfolder"
+
 if [ "${TARGET_ARCH?}" = "aarch64-unknown-linux-gnu" ]; then
-    TARGET_ARG=-target aarch64-linux-gnu
+    TARGET_ARG="-target aarch64-linux-gnu"
+else
+    echo "Unsupported target ${TARGET_ARCH?}" >&2
+    exit 1
 fi
 
 # shellcheck disable=SC2068,2086
-exec zig cc $TARGET_ARG $@
+exec "${zigfolder}/zig" cc $TARGET_ARG $@

--- a/zig.sh
+++ b/zig.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [ "${TARGET_ARCH?}" = "aarch64-unknown-linux-gnu" ]; then
+    TARGET_ARG=-target aarch64-linux-gnu
+fi
+
+# shellcheck disable=SC2068,2086
+exec zig cc $TARGET_ARG $@


### PR DESCRIPTION
Fixed #171

 - Refactor: Create generic zig.sh that can support any num of `TARGET_ARCH`
   instead of just one
 - Refactor: Extract new fn install_zig_cc_and_config_to_use_it
     - improve it so that it will work on {aarch64/x86_64}-apple-darwin
     - imrpove `zig.sh` so that we no longer needs to re-export `PATH`
     - caches zigfolder if possible
 - Build x86_64-unknown-linux-musl using cargo-zigbuild
    - The build-version.sh is now much simpler, without the use of
      `podman`, which also requires us to manually install
      `cargo-auditable`, plus copying out files and the workaround for
      bootstrapping using `--force`
    - We can now use `cmake` for `*-sys` crates
    - Building locally is faster since we no longer has to pull in the
   images.
 - Export env var `PKG_CONFIG` set to our own pkg-config script
   that fails for any input since we cannot use locally installed lib in
   cross-compilation.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>