### PR TITLE
Fix cronjob/weekly-build failure

### DIFF
--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -68,19 +68,25 @@ filter_already_built_crates() {
 }
 
 POPULAR_CRATES=$(
-    if [ "$RECHECK" == 1 ]; then
-        # always check quickinstall first for `make release`
-        echo "cargo-quickinstall"
-    fi
     (
-        ./get-stats.sh |
-            jq 'keys[]' |
-            grep -F "${TARGET_ARCH}" |
-            cut -d '/' -f 1 |
-            cut -c2-
+        (
+            ./get-stats.sh |
+                jq 'keys[]' |
+                grep -F "${TARGET_ARCH}" |
+                cut -d '/' -f 1 |
+                cut -c2-
+        ) || 
+            # If we don't find anything (package stopped being popular?)
+            # then fall back to doing a self-build.
+            echo 'cargo-quickinstall'
 
         # Remove comment and empty lines
         grep -v -e '^#' -e '^[[:space:]]*$' ./popular-crates.txt
+
+        if [ "$RECHECK" == 1 ]; then
+            # always check quickinstall first for `make release`
+            echo "cargo-quickinstall"
+        fi
     ) |
         # Remove duplicate lines, remove exclulded crates
         # Limit max crate to check to 4 * CRATE_CHECK_LIMIT so that we can
@@ -89,14 +95,12 @@ POPULAR_CRATES=$(
         python3 ./dedup-and-exclude.py "${EXCLUDE_FILE?}" "$((4 * CRATE_CHECK_LIMIT))" |
         filter_already_built_crates |
         # -n specifies number of lines to output
-        shuf -n "${CRATE_CHECK_LIMIT}" ||
-        # If we don't find anything (package stopped being popular?)
-        # then fall back to doing a self-build.
-        echo 'cargo-quickinstall'
+        shuf -n "${CRATE_CHECK_LIMIT}"
 )
 
 for CRATE in $POPULAR_CRATES; do
     RESPONSE_FILENAME="$RESPONSE_DIR/$CRATE.json"
+
     VERSION=$(jq -r '.crate|.max_stable_version' "$RESPONSE_FILENAME")
     FEATURES=$(
         jq -r ".versions[] | select(.num == \"$VERSION\") | .features | keys[]" "$RESPONSE_FILENAME" |

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -80,7 +80,10 @@ POPULAR_CRATES=$(
             echo 'cargo-quickinstall'
 
         # Remove comment and empty lines
-        grep -v -e '^#' -e '^[[:space:]]*$' ./popular-crates.txt
+        #
+        # grep might fail due to broken pipe, where ./dedup-and-exclude.py
+        # exits early due to collecting enough output.
+        grep -v -e '^#' -e '^[[:space:]]*$' ./popular-crates.txt || echo true
 
         if [ "$RECHECK" == 1 ]; then
             # always check quickinstall first for `make release`

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -71,10 +71,9 @@ POPULAR_CRATES=$(
     (
         (
             ./get-stats.sh |
-                jq 'keys[]' |
+                jq -r 'keys[]' |
                 grep -F "${TARGET_ARCH}" |
-                cut -d '/' -f 1 |
-                cut -c2-
+                cut -d '/' -f 1
         ) || 
             # If we don't find anything (package stopped being popular?)
             # then fall back to doing a self-build.

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -74,7 +74,7 @@ POPULAR_CRATES=$(
                 jq -r 'keys[]' |
                 grep -F "${TARGET_ARCH}" |
                 cut -d '/' -f 1
-        ) || 
+        ) ||
             # If we don't find anything (package stopped being popular?)
             # then fall back to doing a self-build.
             echo 'cargo-quickinstall'

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -83,7 +83,7 @@ POPULAR_CRATES=$(
         #
         # grep might fail due to broken pipe, where ./dedup-and-exclude.py
         # exits early due to collecting enough output.
-        grep -v -e '^#' -e '^[[:space:]]*$' ./popular-crates.txt || echo true
+        grep -v -e '^#' -e '^[[:space:]]*$' ./popular-crates.txt || true
 
         if [ "$RECHECK" == 1 ]; then
             # always check quickinstall first for `make release`

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -87,7 +87,7 @@ POPULAR_CRATES=$(
 
         if [ "$RECHECK" == 1 ]; then
             # always check quickinstall first for `make release`
-            echo "cargo-quickinstall"
+            echo "cargo-quickinstall" || true
         fi
     ) |
         # Remove duplicate lines, remove exclulded crates


### PR DESCRIPTION
Fix bug in `next-unbuilt-package.sh`: Ensure every crate in `POPULAR_CRATES` already has their crates.io response downloaded.

This would also avoid creating new build for `cargo-quickinstall` when it is already built and uploaded.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>