### PR TITLE
Fix e2etest: Install cargo-nextest v0.9.50 instead of 0.9.28

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Test batch installation with binstall
         run: |
           set -euxo pipefail
-          cargo run -- cargo-quickinstall cargo-nextest@0.9.28
+          cargo run -- cargo-quickinstall cargo-nextest@0.9.50
           cargo quickinstall -V
           cargo nextest -V
 
@@ -107,14 +107,14 @@ jobs:
           set -euxo pipefail
           echo Rm all binaries installed but do not update manifests,
           echo so that binstall will think they are installed.
-          rm $(which cargo-quickinstall) $(which cargo-nextest@0.9.28)
-          cargo run -- --force cargo-quickinstall cargo-nextest@0.9.28
+          rm $(which cargo-quickinstall) $(which cargo-nextest@0.9.50)
+          cargo run -- --force cargo-quickinstall cargo-nextest@0.9.50
           cargo quickinstall -V
           cargo nextest -V
 
       - name: Test batch installation with curl
         run: |
           set -euxo pipefail
-          cargo run -- --no-binstall cargo-quickinstall cargo-nextest@0.9.28
+          cargo run -- --no-binstall cargo-quickinstall cargo-nextest@0.9.50
           cargo quickinstall -V
           cargo nextest -V

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cargo-quickinstall"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "guess_host_triple",
  "home",


### PR DESCRIPTION
since cargo-nextest 0.9.26 isn't available in the new quickinstall release schema BUT cargo-binstall v0.21.x only supports quickinstall new release schema.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>