### PR TITLE
Speedup workflow `selfbuild` and `test` using `sccache`

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,31 @@
+name: Cleanup caches for closed PRs
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.11"
+          version: "v0.4.0"
 
       - name: Build Thyself
         env:
@@ -100,7 +100,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.11"
+          version: "v0.4.0"
       - name: Install Thyself
         run: cargo install --path cargo-quickinstall
       - name: Install Thyself with Thyself (or fallback to sensei on windows)
@@ -150,7 +150,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.11"
+          version: "v0.4.0"
 
       # FIXME: find a package that needs a working CC but doesn't take quite so long to build.
       - name: Build cargo-deny

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
 
 env:
-  SCCACHE_GHA_ENABLED: true
-  RUSTC_WRAPPER: sccache
-  CARGO_INCREMENTAL: 0
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   self-build-with-build-version:

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.10"
+          version: "v0.4.0-pre.11"
 
       - name: Build Thyself
         env:
@@ -100,7 +100,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.10"
+          version: "v0.4.0-pre.11"
       - name: Install Thyself
         run: cargo install --path cargo-quickinstall
       - name: Install Thyself with Thyself (or fallback to sensei on windows)
@@ -150,7 +150,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.10"
+          version: "v0.4.0-pre.11"
 
       # FIXME: find a package that needs a working CC but doesn't take quite so long to build.
       - name: Build cargo-deny

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -3,6 +3,11 @@ name: Self-Build
 on:
   pull_request:
 
+env:
+  SCCACHE_GHA_ENABLED: true
+  RUSTC_WRAPPER: sccache
+  CARGO_INCREMENTAL: 0
+
 jobs:
   self-build-with-build-version:
     name: Self-Build-With-build-version
@@ -44,6 +49,11 @@ jobs:
 
       - name: Install latest rust
         run: rustup toolchain install stable --no-self-update --profile minimal
+
+      - name: Configure sccache
+        uses: mozilla-actions/sccache-action@v0.0.2
+        with:
+          version: "v0.4.0-pre.10"
 
       - name: Build Thyself
         env:
@@ -87,6 +97,10 @@ jobs:
           persist-credentials: false
       - name: Install latest rust
         run: rustup toolchain install stable --no-self-update --profile minimal
+      - name: Configure sccache
+        uses: mozilla-actions/sccache-action@v0.0.2
+        with:
+          version: "v0.4.0-pre.10"
       - name: Install Thyself
         run: cargo install --path cargo-quickinstall
       - name: Install Thyself with Thyself (or fallback to sensei on windows)
@@ -143,9 +157,6 @@ jobs:
         env:
           TARGET_ARCH: ${{ matrix.target_arch }}
           FEATURES: vendored-openssl,vendored-libgit2
-          SCCACHE_GHA_ENABLED: true
-          RUSTC_WRAPPER: sccache
-          CARGO_INCREMENTAL: 0
         run: |
           set -euxo pipefail
           touch .env

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -133,11 +133,19 @@ jobs:
       - name: Install latest rust
         run: rustup toolchain install stable --no-self-update --profile minimal
 
+      - name: Configure sccache
+        uses: mozilla-actions/sccache-action@v0.0.2
+        with:
+          version: "v0.4.0-pre.10"
+
       # FIXME: find a package that needs a working CC but doesn't take quite so long to build.
       - name: Build cargo-deny
         env:
           TARGET_ARCH: ${{ matrix.target_arch }}
           FEATURES: vendored-openssl,vendored-libgit2
+          SCCACHE_GHA_ENABLED: true
+          RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: 0
         run: |
           set -euxo pipefail
           touch .env

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -51,9 +51,7 @@ jobs:
         run: rustup toolchain install stable --no-self-update --profile minimal
 
       - name: Configure sccache
-        uses: mozilla-actions/sccache-action@v0.0.2
-        with:
-          version: "v0.4.0"
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Build Thyself
         env:
@@ -98,9 +96,7 @@ jobs:
       - name: Install latest rust
         run: rustup toolchain install stable --no-self-update --profile minimal
       - name: Configure sccache
-        uses: mozilla-actions/sccache-action@v0.0.2
-        with:
-          version: "v0.4.0"
+        uses: mozilla-actions/sccache-action@v0.0.3
       - name: Install Thyself
         run: cargo install --path cargo-quickinstall
       - name: Install Thyself with Thyself (or fallback to sensei on windows)
@@ -148,9 +144,7 @@ jobs:
         run: rustup toolchain install stable --no-self-update --profile minimal
 
       - name: Configure sccache
-        uses: mozilla-actions/sccache-action@v0.0.2
-        with:
-          version: "v0.4.0"
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       # FIXME: find a package that needs a working CC but doesn't take quite so long to build.
       - name: Build cargo-deny

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.11"
+          version: "v0.4.0"
 
       - name: Clippy
         run: cargo clippy
@@ -65,7 +65,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.11"
+          version: "v0.4.0"
 
       - name: Run test
         run: cargo test
@@ -98,7 +98,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.11"
+          version: "v0.4.0"
 
       - name: Test dry-run
         run: cargo run -- --dry-run cargo-quickinstall

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Configure sccache
-        uses: mozilla-actions/sccache-action@v0.0.2
-        with:
-          version: "v0.4.0"
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Clippy
         run: cargo clippy
@@ -63,9 +61,7 @@ jobs:
         run: git fetch --tags
 
       - name: Configure sccache
-        uses: mozilla-actions/sccache-action@v0.0.2
-        with:
-          version: "v0.4.0"
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Run test
         run: cargo test
@@ -96,9 +92,7 @@ jobs:
         run: rustup toolchain install stable --no-self-update --profile minimal
 
       - name: Configure sccache
-        uses: mozilla-actions/sccache-action@v0.0.2
-        with:
-          version: "v0.4.0"
+        uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: Test dry-run
         run: cargo run -- --dry-run cargo-quickinstall

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.10"
+          version: "v0.4.0-pre.11"
 
       - name: Clippy
         run: cargo clippy
@@ -65,7 +65,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.10"
+          version: "v0.4.0-pre.11"
 
       - name: Run test
         run: cargo test
@@ -98,7 +98,7 @@ jobs:
       - name: Configure sccache
         uses: mozilla-actions/sccache-action@v0.0.2
         with:
-          version: "v0.4.0-pre.10"
+          version: "v0.4.0-pre.11"
 
       - name: Test dry-run
         run: cargo run -- --dry-run cargo-quickinstall

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
       - main
   pull_request:
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   lint:
     name: Linter
@@ -34,6 +39,11 @@ jobs:
       - name: Lint
         run: cargo fmt --check
 
+      - name: Configure sccache
+        uses: mozilla-actions/sccache-action@v0.0.2
+        with:
+          version: "v0.4.0-pre.10"
+
       - name: Clippy
         run: cargo clippy
 
@@ -51,6 +61,11 @@ jobs:
 
       - name: Fetch tags required for testing
         run: git fetch --tags
+
+      - name: Configure sccache
+        uses: mozilla-actions/sccache-action@v0.0.2
+        with:
+          version: "v0.4.0-pre.10"
 
       - name: Run test
         run: cargo test
@@ -79,6 +94,11 @@ jobs:
 
       - name: Install latest rust
         run: rustup toolchain install stable --no-self-update --profile minimal
+
+      - name: Configure sccache
+        uses: mozilla-actions/sccache-action@v0.0.2
+        with:
+          version: "v0.4.0-pre.10"
 
       - name: Test dry-run
         run: cargo run -- --dry-run cargo-quickinstall

--- a/build-version.sh
+++ b/build-version.sh
@@ -116,6 +116,8 @@ export CARGO_PROFILE_RELEASE_LTO="fat"
 export OPENSSL_STATIC=1
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
+export RUST_BACKTRACE=full
+
 echo "PATH=${PATH}"
 rustc -vV
 cargo -vV

--- a/build-version.sh
+++ b/build-version.sh
@@ -131,7 +131,7 @@ cargo install \
 
 if [ "${RUNNER_OS?}" == "Linux" ]; then
     # shellcheck disable=SC2086
-    strace --follow-forks --trace=%process --columns=200 \
+    strace -f --trace=%process --columns=200 \
         cargo-auditable auditable install "$CRATE" \
         --version "$VERSION" \
         --target "$TARGET_ARCH" \

--- a/build-version.sh
+++ b/build-version.sh
@@ -116,11 +116,20 @@ export CARGO_PROFILE_RELEASE_LTO="fat"
 export OPENSSL_STATIC=1
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
+# Remove below
+
 export RUST_BACKTRACE=full
 
 echo "PATH=${PATH}"
 rustc -vV
 cargo -vV
+
+cargo install \
+    --git https://github.com/rust-secure-code/cargo-auditable \
+    --branch fix-sccache-again \
+    cargo-auditable
+
+# Remove above
 
 build_and_install() {
     # shellcheck disable=SC2086

--- a/build-version.sh
+++ b/build-version.sh
@@ -130,7 +130,13 @@ cargo install \
     cargo-auditable
 
 if [ "${RUNNER_OS?}" == "Linux" ]; then
-    strace build_and_install
+    # shellcheck disable=SC2086
+    strace cargo-auditable auditable install "$CRATE" \
+        --version "$VERSION" \
+        --target "$TARGET_ARCH" \
+        --root "$CARGO_ROOT" \
+        ${1:-} \
+        $feature_flag $features
 fi
 
 # Remove above

--- a/build-version.sh
+++ b/build-version.sh
@@ -129,6 +129,10 @@ cargo install \
     --branch fix-sccache-again \
     cargo-auditable
 
+if [ "${RUNNER_OS?}" == "Linux" ]; then
+    strace build_and_install
+fi
+
 # Remove above
 
 build_and_install() {

--- a/build-version.sh
+++ b/build-version.sh
@@ -116,6 +116,10 @@ export CARGO_PROFILE_RELEASE_LTO="fat"
 export OPENSSL_STATIC=1
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
+echo "PATH=${PATH}"
+rustc -vV
+cargo -vV
+
 build_and_install() {
     # shellcheck disable=SC2086
     cargo-auditable auditable install "$CRATE" \

--- a/build-version.sh
+++ b/build-version.sh
@@ -131,7 +131,8 @@ cargo install \
 
 if [ "${RUNNER_OS?}" == "Linux" ]; then
     # shellcheck disable=SC2086
-    strace cargo-auditable auditable install "$CRATE" \
+    strace --follow-forks --trace=%process --columns=200 \
+        cargo-auditable auditable install "$CRATE" \
         --version "$VERSION" \
         --target "$TARGET_ARCH" \
         --root "$CARGO_ROOT" \

--- a/build-version.sh
+++ b/build-version.sh
@@ -116,32 +116,6 @@ export CARGO_PROFILE_RELEASE_LTO="fat"
 export OPENSSL_STATIC=1
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
-# Remove below
-
-export RUST_BACKTRACE=full
-
-echo "PATH=${PATH}"
-rustc -vV
-cargo -vV
-
-cargo install \
-    --git https://github.com/rust-secure-code/cargo-auditable \
-    --branch fix-sccache-again \
-    cargo-auditable
-
-if [ "${RUNNER_OS?}" == "Linux" ]; then
-    # shellcheck disable=SC2086
-    strace -f --trace=%process --columns=200 \
-        cargo-auditable auditable install "$CRATE" \
-        --version "$VERSION" \
-        --target "$TARGET_ARCH" \
-        --root "$CARGO_ROOT" \
-        ${1:-} \
-        $feature_flag $features
-fi
-
-# Remove above
-
 build_and_install() {
     # shellcheck disable=SC2086
     cargo-auditable auditable install "$CRATE" \


### PR DESCRIPTION
 - Use `sccache` to speedup workflow `selfbuild` and `test`.
 - Add workflow `cache-cleanup.yml` to remove unused cache, since GHA does not allow
    main branch to use caches created by another branch.

# TODO
 - [ ] Set `CARGO_BUILD_TARGET_DIR` on workflow using `sccache` for better cache reuse. (`cargo-install` would automatically `mkdir -p "${CARGO_BUILD_TARGET_DIR}`)
 - [ ] Update `cache-cleanup.yml` from cargo-binstall
 - [ ] Use sparse index: `CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse`
   If this is not good enough, then also cache index:
   ```yaml
    - name: Configure index cache
      uses: actions/cache@v3
      with:
         path: |
          ~/.cargo/registry/index/
          ~/.cargo/registry/cache/
          ~/.cargo/git/db/
        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-${{ inputs.cache-suffix }}
        restore-keys: |
          ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-
          ${{ runner.os }}-cargo-index-
   ```
 - [ ] Replace `sccache-action` with taiki-e/install-action
   and then setup environments required manually:
   ```yaml
    - name: Configure sccache
      uses: actions/github-script@v6
      with:
        script: |
          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
   ```


Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>