### PR TITLE
Fix building gitoxide

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -27,6 +27,10 @@ on:
         description: Features to enable
         default: ""
         type: string
+      no_default_features:
+        description: Disable default features
+        default: ""
+        type: string
 
 concurrency:
   group: build-package-${{ github.event.inputs.crate }}-${{ github.event.inputs.version }}-${{ github.event.inputs.target_arch }}
@@ -36,6 +40,7 @@ env:
   TARGET_ARCH: ${{ inputs.target_arch }}
   VERSION: ${{ inputs.version }}
   FEATURES: ${{ inputs.features }}
+  NO_DEFAULT_FEATURES: ${{ inputs.NO_DEFAULT_FEATURES }}
   BUILD_DIR: ${{ github.workspace }}/built.d
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .idea
 .vagrant
+\.DS_Store

--- a/build-version.sh
+++ b/build-version.sh
@@ -13,6 +13,11 @@ else
     feature_flag="--features"
 fi
 
+no_default_features=""
+if [ "${NO_DEFAULT_FEATURES:-}" = "true" ]; then
+    no_default_features='--no-default-features'
+fi
+
 # FIXME: make a signal handler that cleans this up if we exit early.
 if [ ! -d "${TEMPDIR:-}" ]; then
     TEMPDIR="$(mktemp -d)"
@@ -103,6 +108,7 @@ build_and_install() {
         --target "$TARGET_ARCH" \
         --root "$CARGO_ROOT" \
         ${1:-} \
+        $no_default_features \
         $feature_flag $features
 }
 

--- a/next-unbuilt-package.sh
+++ b/next-unbuilt-package.sh
@@ -109,7 +109,13 @@ for CRATE in $POPULAR_CRATES; do
             (grep "^vendored-libgit2\|vendored-openssl$" || true) |
             paste -s -d ',' -
     )
+    NO_DEFAULT_FEATURES=""
+
+    if [ "$CRATE" = "gitoxide" ]; then
+        FEATURES='max-pure'
+        NO_DEFAULT_FEATURES='true'
+    fi
 
     echo "${CRATE}-${VERSION}-${TARGET_ARCH}.tar.gz needs building" >&2
-    echo "{\"crate\": \"$CRATE\", \"version\": \"$VERSION\", \"target_arch\": \"$TARGET_ARCH\", \"features\": \"$FEATURES\"}"
+    echo "{\"crate\": \"$CRATE\", \"version\": \"$VERSION\", \"target_arch\": \"$TARGET_ARCH\", \"features\": \"$FEATURES\", \"no_default_features\": \"$NO_DEFAULT_FEATURES\"}"
 done


### PR DESCRIPTION
`gitoxide` is crate intended to be an alternative of `git`.
It currently fails on cross compilation due to lack of system-wide openssl installation.

It's quite popular, so I think we should fix building `gitoxide` in quickinstall.

According to @Byron in https://github.com/Byron/gitoxide/issues/809 , we can fix the by building gitoxide with `--no-default-features --featulres max-pure`.

 - Add new input `no_default_features` to `build-package.yml`
 - Build gitoxide with `--no-default-features --features max-pure`
 - Add `\.DS_Store` to `.gitignore`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>