### PR TITLE
Use `Cargo.lock` in `build-version.sh`

### DIFF
--- a/build-version.sh
+++ b/build-version.sh
@@ -121,6 +121,7 @@ build_and_install() {
         --version "$VERSION" \
         --target "$TARGET_ARCH" \
         --root "$CARGO_ROOT" \
+        --locked \
         ${1:-} \
         $no_default_features \
         $feature_flag $features


### PR DESCRIPTION
to ensure that we would use the same version of dependencies the upstream uses and works.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>