### PR TITLE
Added nextest & llvm-cov crates.

### DIFF
--- a/popular-crates.txt
+++ b/popular-crates.txt
@@ -46,6 +46,8 @@ semantic-release-cargo
 zellij
 topgrade
 cargo-generate
+cargo-nextest
+cargo-llvm-cov
 ####################################
 b3sum
 bandwhich


### PR DESCRIPTION
I'm proposing to add two more crates which are useful in CI context:
1. [`cargo-nextest`](https://github.com/nextest-rs/nextest) is a modern [test runner](https://nexte.st/) which is capable to provide `junit.xml` suitable for ingeration with other tools like GitLab;
2. [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) is yet another code coverage tool gaining popularity;