### PR TITLE
Fix test_get_latest_version

### DIFF
--- a/cargo-quickinstall/tests/integration_tests.rs
+++ b/cargo-quickinstall/tests/integration_tests.rs
@@ -70,5 +70,8 @@ fn do_dry_run_for_nonexistent_package() {
 
 #[test]
 fn test_get_latest_version() {
-    assert_eq!(get_latest_version("cargo-quickinstall").unwrap(), env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        get_latest_version("cargo-quickinstall").unwrap(),
+        env!("CARGO_PKG_VERSION")
+    );
 }

--- a/cargo-quickinstall/tests/integration_tests.rs
+++ b/cargo-quickinstall/tests/integration_tests.rs
@@ -70,26 +70,5 @@ fn do_dry_run_for_nonexistent_package() {
 
 #[test]
 fn test_get_latest_version() {
-    let stdout = std::process::Command::new("git")
-        .args([
-            "tag",
-            "--list",
-            "--sort=-version:refname",
-            "cargo-quickinstall-v*",
-        ])
-        .output_checked_status()
-        .unwrap()
-        .stdout;
-    let stdout = String::from_utf8_lossy(&stdout);
-
-    let version = stdout
-        .trim()
-        .lines()
-        .next()
-        .unwrap()
-        .trim()
-        .strip_prefix("cargo-quickinstall-v")
-        .unwrap();
-
-    assert_eq!(get_latest_version("cargo-quickinstall").unwrap(), version);
+    assert_eq!(get_latest_version("cargo-quickinstall").unwrap(), env!("CARGO_PKG_VERSION"));
 }


### PR DESCRIPTION
It would be temporarily broken during release, but this is the most robust