### PR TITLE
report stats to new server, with status

### DIFF
--- a/cargo-quickinstall/src/install_error.rs
+++ b/cargo-quickinstall/src/install_error.rs
@@ -107,3 +107,37 @@ impl From<JsonExtError> for InstallError {
         InstallError::JsonErr(err)
     }
 }
+
+#[derive(Debug)]
+pub enum InstallSuccess {
+    InstalledFromTarball,
+    BuiltFromSource,
+}
+
+/**
+ * Returns a status string for reporting to our stats server.
+ *
+ * The return type is a static string to encourage us to keep the cardinality vaguely small-ish,
+ * and avoid us accidentally dumping personally identifiable information into influxdb.
+ *
+ * If we find ourselves getting a lot of a particular genre of error, we can always make a new
+ * release to split things out a bit more.
+ *
+ * There is no requirement for cargo-quickinstall and cargo-binstall to agree on the status strings,
+ * but it is probably a good idea to keep at least the first two in sync.
+ */
+pub fn install_result_to_status_str(result: &Result<InstallSuccess, InstallError>) -> &'static str {
+    match result {
+        Ok(InstallSuccess::InstalledFromTarball) => "installed-from-tarball",
+        Ok(InstallSuccess::BuiltFromSource) => "built-from-source",
+        Err(InstallError::MissingCrateNameArgument(_)) => "missing-crate-name-argument",
+        Err(InstallError::CommandFailed(_)) => "command-failed",
+        Err(InstallError::IoError(_)) => "io-error",
+        Err(InstallError::CargoInstallFailed) => "cargo-install-failed",
+        Err(InstallError::CrateDoesNotExist { .. }) => "crate-does-not-exist",
+        Err(InstallError::NoFallback(_)) => "no-fallback",
+        Err(InstallError::InvalidJson { .. }) => "invalid-json",
+        Err(InstallError::JsonErr(_)) => "json-err",
+        Err(InstallError::FailToParseRustcOutput { .. }) => "fail-to-parse-rustc-output",
+    }
+}

--- a/cargo-quickinstall/src/install_error.rs
+++ b/cargo-quickinstall/src/install_error.rs
@@ -130,14 +130,14 @@ pub fn install_result_to_status_str(result: &Result<InstallSuccess, InstallError
     match result {
         Ok(InstallSuccess::InstalledFromTarball) => "installed-from-tarball",
         Ok(InstallSuccess::BuiltFromSource) => "built-from-source",
-        Err(InstallError::MissingCrateNameArgument(_)) => "missing-crate-name-argument",
-        Err(InstallError::CommandFailed(_)) => "command-failed",
-        Err(InstallError::IoError(_)) => "io-error",
         Err(InstallError::CargoInstallFailed) => "cargo-install-failed",
-        Err(InstallError::CrateDoesNotExist { .. }) => "crate-does-not-exist",
         Err(InstallError::NoFallback(_)) => "no-fallback",
-        Err(InstallError::InvalidJson { .. }) => "invalid-json",
-        Err(InstallError::JsonErr(_)) => "json-err",
-        Err(InstallError::FailToParseRustcOutput { .. }) => "fail-to-parse-rustc-output",
+        Err(InstallError::MissingCrateNameArgument(_))
+        | Err(InstallError::CommandFailed(_))
+        | Err(InstallError::IoError(_))
+        | Err(InstallError::CrateDoesNotExist { .. })
+        | Err(InstallError::InvalidJson { .. })
+        | Err(InstallError::JsonErr(_))
+        | Err(InstallError::FailToParseRustcOutput { .. }) => "other-error",
     }
 }

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -112,7 +112,10 @@ pub fn get_cargo_binstall_version() -> Option<String> {
     String::from_utf8(output.stdout).ok()
 }
 
-pub fn install_crate_curl(details: &CrateDetails, fallback: bool) -> Result<(), InstallError> {
+pub fn install_crate_curl(
+    details: &CrateDetails,
+    fallback: bool,
+) -> Result<InstallSuccess, InstallError> {
     let urls = get_quickinstall_download_urls(details);
 
     let res = match curl_and_untar(&urls[0]) {
@@ -135,7 +138,7 @@ pub fn install_crate_curl(details: &CrateDetails, fallback: bool) -> Result<(), 
                 version = details.version,
                 bin_dir = bin_dir.display(),
             );
-            Ok(())
+            Ok(InstallSuccess::InstalledFromTarball)
         }
         Err(err) if err.is_curl_404() => {
             if !fallback {
@@ -153,7 +156,7 @@ pub fn install_crate_curl(details: &CrateDetails, fallback: bool) -> Result<(), 
             let status = prepare_cargo_install_cmd(details).status()?;
 
             if status.success() {
-                Ok(())
+                Ok(InstallSuccess::BuiltFromSource)
             } else {
                 Err(InstallError::CargoInstallFailed)
             }
@@ -237,22 +240,42 @@ fn get_target_triple_from_rustc() -> Result<String, InstallError> {
     Ok(parts.join("-"))
 }
 
-pub fn report_stats_in_background(details: &CrateDetails) {
+pub fn report_stats_in_background(
+    details: &CrateDetails,
+    result: &Result<InstallSuccess, InstallError>,
+) {
+    let status = install_result_to_status_str(result);
     let stats_url = format!(
-        "https://warehouse-clerk-tmp.vercel.app/api/crate/{}-{}-{}.tar.gz",
-        details.crate_name, details.version, details.target
+        "https://cargo-quickinstall-stats-server.fly.dev/record-install?crate={}&version={}&target={}&status={}",
+        url_encode(&details.crate_name),
+        url_encode(&details.version),
+        url_encode(&details.target),
+        status,
     );
 
     // Simply spawn the curl command to report stat.
     //
     // It's ok for it to fail and we would let the init process reap
     // the `curl` process.
-    prepare_curl_head_cmd(&stats_url)
+    prepare_curl_post_cmd(&stats_url)
         .stdin(process::Stdio::null())
         .stdout(process::Stdio::null())
         .stderr(process::Stdio::null())
         .spawn()
         .ok();
+}
+
+fn url_encode(input: &str) -> String {
+    let mut encoded = String::with_capacity(input.len());
+
+    for c in input.chars() {
+        match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => encoded.push(c),
+            _ => encoded.push_str(&format!("%{:02X}", c as u8)),
+        }
+    }
+
+    encoded
 }
 
 fn format_curl_and_untar_cmd(url: &str, bin_dir: &Path) -> String {
@@ -316,6 +339,12 @@ fn untar(mut curl: ChildWithCommand) -> Result<String, InstallError> {
 fn prepare_curl_head_cmd(url: &str) -> std::process::Command {
     let mut cmd = prepare_curl_cmd();
     cmd.arg("--head").arg(url);
+    cmd
+}
+
+fn prepare_curl_post_cmd(url: &str) -> std::process::Command {
+    let mut cmd = prepare_curl_cmd();
+    cmd.args(["-X", "POST"]).arg(url);
     cmd
 }
 

--- a/cargo-quickinstall/src/lib.rs
+++ b/cargo-quickinstall/src/lib.rs
@@ -244,13 +244,13 @@ pub fn report_stats_in_background(
     details: &CrateDetails,
     result: &Result<InstallSuccess, InstallError>,
 ) {
-    let status = install_result_to_status_str(result);
     let stats_url = format!(
-        "https://cargo-quickinstall-stats-server.fly.dev/record-install?crate={}&version={}&target={}&status={}",
-        url_encode(&details.crate_name),
-        url_encode(&details.version),
-        url_encode(&details.target),
-        status,
+        "https://cargo-quickinstall-stats-server.fly.dev/record-install?crate={crate}&version={version}&target={target}&agent={agent}&status={status}",
+        crate = url_encode(&details.crate_name),
+        version = url_encode(&details.version),
+        target = url_encode(&details.target),
+        agent = url_encode(concat!("cargo-quickinstall/", env!("CARGO_PKG_VERSION"))),
+        status = install_result_to_status_str(result),
     );
 
     // Simply spawn the curl command to report stat.

--- a/cargo-quickinstall/src/main.rs
+++ b/cargo-quickinstall/src/main.rs
@@ -91,8 +91,9 @@ fn do_main_curl(
             let shell_cmd = do_dry_run_curl(&crate_details, args.fallback)?;
             println!("{}", shell_cmd);
         } else {
-            report_stats_in_background(&crate_details);
-            install_crate_curl(&crate_details, args.fallback)?;
+            let result = install_crate_curl(&crate_details, args.fallback);
+            report_stats_in_background(&crate_details, &result);
+            result?;
         }
     }
 

--- a/stats-server/src/main.rs
+++ b/stats-server/src/main.rs
@@ -47,7 +47,11 @@ async fn record_install(Query(params): Query<BTreeMap<String, String>>) -> Strin
 
     let mut point = Measurement::builder("counts").field("count", 1);
     for (tag, value) in &params {
-        point = point.tag(tag, &**value)
+        if !["crate", "version", "target", "status"].contains(&tag.as_str()) {
+            println!("Skipping unknown query param: {tag}={value}");
+            continue;
+        }
+        point = point.tag(tag, value.as_str())
     }
     INFLUX_CLIENT
         .write(&INFLUX_BUCKET, &[point.build().unwrap()])

--- a/stats-server/src/main.rs
+++ b/stats-server/src/main.rs
@@ -47,7 +47,7 @@ async fn record_install(Query(params): Query<BTreeMap<String, String>>) -> Strin
 
     let mut point = Measurement::builder("counts").field("count", 1);
     for (tag, value) in &params {
-        if !["crate", "version", "target", "status"].contains(&tag.as_str()) {
+        if !["crate", "version", "target", "agent", "status"].contains(&tag.as_str()) {
             println!("Skipping unknown query param: {tag}={value}");
             continue;
         }


### PR DESCRIPTION
This requires us to move the reporting to happen after we've done the install, but let's not quibble about a few milliseconds here or there, when we may have saved the user multiple minutes.

Also drop unknown query params in server now that we have a good idea of  which stats we want to collect. If anyone wants to track anything else, it should be easy enough to add them here as a pull request.

Feel free to rip into my rust. It is about as rusty as my python ;-).