### PR TITLE
Fix python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ trigger-all: cronjob_scripts/.python-deps-updated.timestamp ## build some random
 .PHONY: test-cronjob-scripts
 test-cronjob-scripts: cronjob_scripts/.python-deps-updated.timestamp ## run the tests for the python cronjob_scripts
 	python -m unittest discover -s cronjob_scripts
+	python cronjob_scripts/trigger-package-build.py --help
 
 .PHONY: help
 help: ## Display this help screen

--- a/cronjob_scripts/architectures.py
+++ b/cronjob_scripts/architectures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 

--- a/cronjob_scripts/trigger-package-build.py
+++ b/cronjob_scripts/trigger-package-build.py
@@ -179,4 +179,9 @@ def get_current_version_if_unbuilt(
 
 
 if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        print("Usage: INFLUXDB_TOKEN= TARGET_ARCH= CRATE_CHECK_LIMIT= RECHECK= GITHUB_REPOSITORY= trigger-package-build.py")
+        if sys.argv[1] == "--help":
+            exit(0)
+        exit(1)
     main()


### PR DESCRIPTION
python 3.8 doesn't understand `list[str]` as a type annotation at runtime (see error in https://github.com/cargo-bins/cargo-quickinstall/issues/282).

This wasn't caught because I was accidentally smoke-testing locally on a more modern python.

I was also pushing to the actions branch to test on CI, but forgot to do that between making a last minute refactor and merging to main.

I think this test will avoid similar problems with shipping broken python code.

Note that we don't do any mypy type checking in CI, so it's up to whatever you have enabled in your IDE to catch any discrepancies.