### PR TITLE
redirect to / when people's browsers are directed to /record-install by cargo-binstall

### DIFF
--- a/stats-server/src/main.rs
+++ b/stats-server/src/main.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 
 use axum::{
     extract::Query,
+    response::Redirect,
     routing::{get, post},
     Router,
 };
@@ -23,6 +24,7 @@ fn main() {
     let task = rt.spawn(async move {
         let app = Router::new()
             .route("/", get(root))
+            .route("/record-install", get(redirect_to_root))
             .route("/record-install", post(record_install));
 
         // ipv6 + ipv6 any addr
@@ -40,6 +42,10 @@ async fn root() -> &'static str {
 
 fn get_env(key: &str) -> String {
     std::env::var(key).expect(&format!("{key} must be set"))
+}
+
+async fn redirect_to_root() -> Redirect {
+    Redirect::to("/")
 }
 
 async fn record_install(Query(params): Query<BTreeMap<String, String>>) -> String {


### PR DESCRIPTION
I just pushed https://github.com/cargo-bins/cargo-binstall/pull/1912 which points users to https://cargo-quickinstall-stats-server.fly.dev/record-install

If you go there, it previously returned a 405 "method forbidden" error.

I have changed it so that it now redirects to /.

I already made the deploy. Feel free to merge if you're happy with this.