### PR TITLE
Enable all feature including "bundled"

### DIFF
--- a/cronjob_scripts/trigger-package-build.py
+++ b/cronjob_scripts/trigger-package-build.py
@@ -80,7 +80,7 @@ def trigger_for_arch(target_arch: str):
             features = "vendored-openssl"
         else:
             features = ",".join(
-                feat for feat in version["features"].keys() if "vendored" in feat or bundled in feat
+                feat for feat in version["features"].keys() if "vendored" in feat or "bundled" in feat
             )
 
         workflow_run_input = {

--- a/cronjob_scripts/trigger-package-build.py
+++ b/cronjob_scripts/trigger-package-build.py
@@ -80,7 +80,7 @@ def trigger_for_arch(target_arch: str):
             features = "vendored-openssl"
         else:
             features = ",".join(
-                feat for feat in version["features"].keys() if "vendored" in feat
+                feat for feat in version["features"].keys() if "vendored" in feat or bundled in feat
             )
 
         workflow_run_input = {


### PR DESCRIPTION
Motivation:

Some crates, e.g. https://docs.rs/crate/cargo-docset/latest/features , have a `bundled-*` feature to build a vendored C/C++ library, which is necessary for cross-compilation and reliable distribution.