### PR TITLE
Bump dep influrs for stats-server to 3.0

### DIFF
--- a/stats-server/Cargo.lock
+++ b/stats-server/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.74+curl-8.9.0"
+version = "0.4.76+curl-8.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af10b986114528fcdc4b63b6f5f021b7057618411046a4de2ba0f0149a097bf"
+checksum = "00462dbe9cbb9344e1b2be34d9094d74e3b8aac59a883495b335eafd02e25120"
 dependencies = [
  "cc",
  "libc",
@@ -434,8 +434,9 @@ dependencies = [
 
 [[package]]
 name = "influxrs"
-version = "2.0.1"
-source = "git+https://github.com/alsuren/influxrs?rev=bc037531ef31e0a19014556120ecdd151427561b#bc037531ef31e0a19014556120ecdd151427561b"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2b0b3d0ecac700fd3b3833d8faf40e3606e9759fa232758998a098a69670c5"
 dependencies = [
  "csv",
  "isahc",
@@ -637,9 +638,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polling"
@@ -961,9 +962,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]

--- a/stats-server/Cargo.toml
+++ b/stats-server/Cargo.toml
@@ -6,14 +6,13 @@ authors = ["David Laban <alsuren@gmail.com>"]
 edition = "2021"
 publish = false
 
-# Make a new workspace so that we get our own Cargo.lock and target dir for the docker build. 
+# Make a new workspace so that we get our own Cargo.lock and target dir for the docker build.
 [workspace]
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 axum = "0.7"
-# FIXME: revert back to using crates.io once https://github.com/ijagberg/influx/pull/5 is released
-influxrs = { git = "https://github.com/alsuren/influxrs", rev = "bc037531ef31e0a19014556120ecdd151427561b" }
+influxrs = { version = "3", features = ["client"] }
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
influxrs 2.1 has included the escape fix, so using a fork is no longer necessary.