### PR TITLE
revert influx lib upgrade; Influx smoke test before listening on http port.

### DIFF
--- a/.github/workflows/deploy-stats-server.yml
+++ b/.github/workflows/deploy-stats-server.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy stats-server
+      - run: flyctl deploy stats-server --wait-timeout 1m
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/stats-server/Cargo.lock
+++ b/stats-server/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.76+curl-8.10.1"
+version = "0.4.74+curl-8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00462dbe9cbb9344e1b2be34d9094d74e3b8aac59a883495b335eafd02e25120"
+checksum = "8af10b986114528fcdc4b63b6f5f021b7057618411046a4de2ba0f0149a097bf"
 dependencies = [
  "cc",
  "libc",
@@ -434,9 +434,8 @@ dependencies = [
 
 [[package]]
 name = "influxrs"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2b0b3d0ecac700fd3b3833d8faf40e3606e9759fa232758998a098a69670c5"
+version = "2.0.1"
+source = "git+https://github.com/alsuren/influxrs?rev=bc037531ef31e0a19014556120ecdd151427561b#bc037531ef31e0a19014556120ecdd151427561b"
 dependencies = [
  "csv",
  "isahc",
@@ -638,9 +637,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "polling"
@@ -962,9 +961,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]

--- a/stats-server/Cargo.toml
+++ b/stats-server/Cargo.toml
@@ -6,13 +6,14 @@ authors = ["David Laban <alsuren@gmail.com>"]
 edition = "2021"
 publish = false
 
-# Make a new workspace so that we get our own Cargo.lock and target dir for the docker build.
+# Make a new workspace so that we get our own Cargo.lock and target dir for the docker build. 
 [workspace]
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 axum = "0.7"
-influxrs = { version = "3", features = ["client"] }
+# FIXME: revert back to using crates.io once https://github.com/ijagberg/influx/pull/5 is released
+influxrs = { git = "https://github.com/alsuren/influxrs", rev = "bc037531ef31e0a19014556120ecdd151427561b" }
 
 [profile.release]
 lto = "thin"

--- a/stats-server/fly.toml
+++ b/stats-server/fly.toml
@@ -3,6 +3,7 @@
 app = "cargo-quickinstall-stats-server"
 kill_signal = "SIGINT"
 kill_timeout = 5
+deploy.strategy = "bluegreen"
 
 [env]
   PORT = "8080"

--- a/stats-server/src/main.rs
+++ b/stats-server/src/main.rs
@@ -27,6 +27,18 @@ fn main() {
             .route("/record-install", get(redirect_to_root))
             .route("/record-install", post(record_install));
 
+        // Smoke test that we can write to influxdb before listening on the socket.
+        // This is a poor man's startup probe to avoid serving traffic before we can write to influxdb.
+        INFLUX_CLIENT
+            .write(
+                &INFLUX_BUCKET,
+                &[Measurement::builder("startups")
+                    .field("count", 1)
+                    .build()
+                    .unwrap()],
+            )
+            .await
+            .unwrap();
         // ipv6 + ipv6 any addr
         let addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], 8080));
         let listener = TcpListener::bind(addr).await.unwrap();


### PR DESCRIPTION
This reverts #303 because it is causing the following in our logs: https://fly.io/apps/cargo-quickinstall-stats-server/monitoring

```
2024-10-01T15:14:50.843 app[7811ee7a2566e8] iad [info] called `Result::unwrap()` on an `Err` value: NonSuccessResponse(400, "{\"code\":\"invalid\",\"message\":\"no data written, errors encountered on line(s): line 1: timestamp value overflows after adjusting for specified precision\",\"line\":1}")
```

I'm not in the mood to debug it right now, but I **think** that if the new docker container fails to come up, the old one should stay in the load balancer and prevent an outage (note: this is not the case with the default strategy, but it is with the bluegreen strategy). 

- [x] test this theory by trying to deploy the broken code

With the healthcheck and a bluegreen deployment strategy, we get a nonzero exit code from `flyctl deploy`, and this in its output:

```
Updating existing machines in 'cargo-quickinstall-stats-server' with bluegreen strategy

Verifying if app can be safely deployed 

Creating green machines
  Created machine 080e3e1a021098 [app]

Waiting for all green machines to start
  Machine 080e3e1a021098 [app] - started

Waiting for all green machines to be healthy
  Machine 080e3e1a021098 [app] - unchecked

Rolling back failed deployment
  Deleted machine 080e3e1a021098 [app]
Error: wait timeout
could not get all green machines to be healthy
```

This is enough to leave production in a healthy state and give us a build failure notification on the merge-to-main github action. 

Unfortunately, it leaves main in a broken state, and requires a maintainer with access to https://fly.io/apps/cargo-quickinstall-stats-server/monitoring to debug the issue.

Ideally, we would also have an integration test that spins up an influxdb 3 server in a docker container and tries to report stats to it. Unfortunately there are no influxdb3 docker images yet. In practice we could probably use an influxdb 2 image, because the stats reporting wire format shouldn't have changed.

Let's just get the stats server back on its feet for now.