### PR TITLE
Squash warning after embed-resource version bump; enable clippy in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,8 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run cargo clippy for stats-server project
-        run: (cd stats-server && cargo clippy --all-targets --all-features -- -D warnings)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+        working-directory: stats-server
 
       - name: Run cargo test
         run: cargo test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Fetch tags required for testing
         run: git fetch --tags
 
+      - name: Run cargo clippy for client project
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run cargo clippy for stats-server project
+        run: (cd stats-server && cargo clippy --all-targets --all-features -- -D warnings)
+
       - name: Run cargo test
         run: cargo test
 

--- a/cargo-quickinstall/build.rs
+++ b/cargo-quickinstall/build.rs
@@ -3,5 +3,7 @@ fn main() {
     println!("cargo:rerun-if-changed=manifest.rc");
     println!("cargo:rerun-if-changed=windows.manifest");
 
-    embed_resource::compile("manifest.rc", embed_resource::NONE);
+    embed_resource::compile("manifest.rc", embed_resource::NONE)
+        .manifest_required()
+        .unwrap();
 }

--- a/stats-server/src/main.rs
+++ b/stats-server/src/main.rs
@@ -53,7 +53,7 @@ async fn root() -> &'static str {
 }
 
 fn get_env(key: &str) -> String {
-    std::env::var(key).expect(&format!("{key} must be set"))
+    std::env::var(key).unwrap_or_else(|_| panic!("{key} must be set"))
 }
 
 async fn redirect_to_root() -> Redirect {


### PR DESCRIPTION
I just pulled main and got:

```
warning: unused `embed_resource::CompilationResult` that must be used
 --> cargo-quickinstall/build.rs:6:5
  |
6 |     embed_resource::compile("manifest.rc", embed_resource::NONE);
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `-D unused-must-use` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_must_use)]`
help: use `let _ = ...` to ignore the resulting value
  |
6 |     let _ = embed_resource::compile("manifest.rc", embed_resource::NONE);
  |     +++++++

warning: `cargo-quickinstall` (build script) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
```

This seems like it was caused by #319 and not caught by our CI.

I also ran clippy in the stats-server project and found another warning.