### PR TITLE
Fix link to list of supported targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Edit the command however you need, and paste it into your CI pipeline.
 
 ## Supported targets
 
-Check [supported-targets](/cronjob_scripts/trigger-package-build.py) for lists of targets quickinstall
+Check [supported-targets](/supported-targets) for lists of targets quickinstall
 can build for.
 
 ## Limitations


### PR DESCRIPTION
This points the "supported-targets" link in the readme back to the `supported-targets` file, which it had originally linked to and which its text suggests it is still intended to link to.

After #275, the readme link to the supported targets list pointed to the `trigger-package-build.py` script. This appears to have been based on idea of removing the `supported-targets` file. As noted in https://github.com/cargo-bins/cargo-quickinstall/pull/275/files#r1747798959, the file was not removed. But the link target was not restored.

As long as the file does exist, it is easier for users reading the readme to consult it rather than examine a script. In addition, the link was fully broken since #300 when the script was rewritten and named `trigger_package_build.py` (with underscores).