### PR TITLE
Fix release-plz.yml failure in cargo-quickinstall release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: Release-plz
 permissions:
   pull-requests: write
   contents: write
+  actions: write
 
 on:
   push:


### PR DESCRIPTION
https://github.com/cargo-bins/cargo-quickinstall/actions/runs/13629805962

This happens because it doesn't have the permission to trigger action, it's added in this commit