### PR TITLE
Get cronjob working again after I deleted the deploy key

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -171,7 +171,6 @@ jobs:
       - name: Checkout trigger commit
         uses: actions/checkout@v5
         with:
-          ssh-key: ${{ secrets.CRONJOB_DEPLOY_KEY }}
           persist-credentials: true
           path: trigger
       - name: Checkout main repo
@@ -273,7 +272,6 @@ jobs:
       - name: Checkout trigger branch
         uses: actions/checkout@v5
         with:
-          ssh-key: ${{ secrets.CRONJOB_DEPLOY_KEY }}
           persist-credentials: true
           ref: trigger/${{ inputs.target_arch }}
           path: trigger

--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -10,7 +10,7 @@ on:
   # If you are an upstream maintainer and you want to test your branch before merging, run
   #
   #     git push
-  #     gh workflow run cronjob.yml --ref `git rev-parse --abbrev-ref HEAD`
+  #     gh workflow run cronjob.yml --ref $(git rev-parse --abbrev-ref HEAD)
   #     gh run list --workflow=cronjob.yml -L1 --json url
   #
   # This may also work on forks, but you might need to set up some repo secrets first,

--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -27,7 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ssh-key: ${{ secrets.CRONJOB_DEPLOY_KEY }}
           persist-credentials: true
 
       - uses: ./.github/actions/cronjob-setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,35 +125,35 @@ jobs:
       - name: Test batch installation with binstall
         run: |
           set -euxo pipefail
-          cargo run -- cargo-quickinstall cargo-nextest@0.9.50
+          cargo run -- cargo-quickinstall cargo-update@18.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Try running the binary
         run: |
           cargo quickinstall -V
-          cargo nextest -V
+          cargo install-update -V
 
       - name: Test batch installation with binstall with force
         run: |
           set -euxo pipefail
           echo Rm all binaries installed but do not update manifests,
           echo so that binstall will think they are installed.
-          rm $(which cargo-quickinstall) $(which cargo-nextest@0.9.50)
-          cargo run -- --force cargo-quickinstall cargo-nextest@0.9.50
+          rm $(which cargo-quickinstall) $(which cargo-update@18.0.0)
+          cargo run -- --force cargo-quickinstall cargo-update@18.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Try running the binary
         run: |
           cargo quickinstall -V
-          cargo nextest -V
+          cargo install-update -V
       - name: Test batch installation with curl
         run: |
           set -euxo pipefail
-          cargo run -- --no-binstall cargo-quickinstall cargo-nextest@0.9.50
+          cargo run -- --no-binstall cargo-quickinstall cargo-update@18.0.0
           cargo quickinstall -V
-          cargo nextest -V
+          cargo install-update -V
 
   # Dummy job to have a stable name for the "all tests pass" requirement
   automated-tests-pass:

--- a/cargo-quickinstall/src/install_error.rs
+++ b/cargo-quickinstall/src/install_error.rs
@@ -20,7 +20,7 @@ impl InstallError {
         matches!(
             self,
             Self::CommandFailed(CommandFailed { stderr, .. })
-            if stderr.contains("curl: (22) The requested URL returned error: 404")
+            if stderr.contains("The requested URL returned error: 404")
         )
     }
 }

--- a/cargo-quickinstall/tests/integration_tests.rs
+++ b/cargo-quickinstall/tests/integration_tests.rs
@@ -1,12 +1,12 @@
 use cargo_quickinstall::*;
 use std::process;
 
-/// Tests installation of Ripgrep.
+/// Tests installation of cargo-update.
 ///
-/// A prebuilt package of Ripgrep version 13.0.0 for Linux x86_64 is known to
+/// A prebuilt package of cargo-update version 18.0.0 for Linux x86_64 is known to
 /// exist.  This should lead to a successful quickinstall.
 #[test]
-fn quickinstall_for_ripgrep() {
+fn quickinstall_for_cargo_update() {
     let tmp_cargo_home_dir = mktemp::Temp::new_dir().unwrap();
 
     let tmp_cargo_bin_dir = tmp_cargo_home_dir.as_path().join("bin");
@@ -15,8 +15,8 @@ fn quickinstall_for_ripgrep() {
     std::env::set_var("CARGO_HOME", tmp_cargo_home_dir.as_path());
 
     let crate_details = CrateDetails {
-        crate_name: "ripgrep".to_string(),
-        version: "13.0.0".to_string(),
+        crate_name: "cargo-update".to_string(),
+        version: "18.0.0".to_string(),
         target: get_target_triple().unwrap(),
     };
     let do_not_fallback_on_cargo_install = false;
@@ -25,32 +25,32 @@ fn quickinstall_for_ripgrep() {
 
     assert!(result.is_ok(), "{}", result.err().unwrap());
 
-    let mut ripgrep_path = tmp_cargo_bin_dir;
-    ripgrep_path.push("rg");
+    let mut cargo_update_path = tmp_cargo_bin_dir;
+    cargo_update_path.push("cargo-install-update-config");
 
-    assert!(ripgrep_path.is_file());
+    assert!(cargo_update_path.is_file());
 
-    std::process::Command::new(ripgrep_path)
+    std::process::Command::new(cargo_update_path)
         .arg("-V")
         .output_checked_status()
         .unwrap();
 }
 
-/// Tests dry run for Ripgrep.
+/// Tests dry run for cargo-update.
 ///
-/// A prebuilt package of Ripgrep version 13.0.0 for Linux x86_64 is known to
+/// A prebuilt package of cargo-update version 18.0.0 for Linux x86_64 is known to
 /// exist.
 #[test]
-fn do_dry_run_for_ripgrep() {
+fn do_dry_run_for_cargo_update() {
     let crate_details = CrateDetails {
-        crate_name: "ripgrep".to_string(),
-        version: "13.0.0".to_string(),
+        crate_name: "cargo-update".to_string(),
+        version: "18.0.0".to_string(),
         target: "x86_64-unknown-linux-gnu".to_string(),
     };
 
     let result = do_dry_run_curl(&crate_details, false).unwrap();
 
-    let expected_prefix = concat!("curl --user-agent \"cargo-quickinstall/", env!("CARGO_PKG_VERSION"), " client (alsuren@gmail.com)\" --location --silent --show-error --fail \"https://github.com/cargo-bins/cargo-quickinstall/releases/download/ripgrep-13.0.0/ripgrep-13.0.0-x86_64-unknown-linux-gnu.tar.gz\" | tar -xzvvf -");
+    let expected_prefix = concat!("curl --user-agent \"cargo-quickinstall/", env!("CARGO_PKG_VERSION"), " client (alsuren@gmail.com)\" --location --silent --show-error --fail \"https://github.com/cargo-bins/cargo-quickinstall/releases/download/cargo-update-18.0.0/cargo-update-18.0.0-x86_64-unknown-linux-gnu.tar.gz\" | tar -xzvvf -");
     assert_eq!(&result[..expected_prefix.len()], expected_prefix);
 }
 


### PR DESCRIPTION
The SSH Deploy key was previously used to trigger cascades of workflows by pushing to the relevant trigger branches. We don't do this anymore, but we were still using the deploy key to do the initial checkout in the cronjob workflow. I deleted it as part of my reponse to #441, and the cronjob [started failing](https://github.com/cargo-bins/cargo-quickinstall/actions/runs/17346869585) when I re-enabled it.