### PR TITLE
Update and pin GitHub Actions

### DIFF
--- a/.github/actions/cache-cargo-install/action.yml
+++ b/.github/actions/cache-cargo-install/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
       if: runner.os != 'Windows'
         
-    - uses: actions/cache@v4
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.CARGO_TARGET_DIR }}
         key: ${{ runner.os }}-${{ matrix.target_arch }}-${{ github.workflow }}-${{ github.job }}

--- a/.github/actions/cronjob-setup/action.yml
+++ b/.github/actions/cronjob-setup/action.yml
@@ -3,7 +3,7 @@ name: Setup env for cronjob and cache
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version-file: "cronjob_scripts/.python-version"
         cache: "pip"
@@ -14,7 +14,7 @@ runs:
       shell: bash
 
     - name: Cache crates-io popular crates
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: cached_crates_io_popular_crates.parquet
         key: ${{ env.NOW }}-cached_crates_io_popular_crates.parquet

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -109,12 +109,12 @@ jobs:
         shell: bash
     steps:
       - name: Checkout trigger commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           path: trigger
       - name: Checkout main repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           ref: ${{ inputs.branch }}
@@ -151,7 +151,7 @@ jobs:
       # TODO: try breaking things so that uploads don't work.
 
       - name: Upload run-local binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: built-${{ inputs.build_os }}
           path: ${{ env.BUILD_DIR }}
@@ -169,12 +169,12 @@ jobs:
       SIG_FILENAME: ${{ github.workspace }}/built.d/${{ inputs.crate }}-${{ inputs.version }}-${{ inputs.target_arch }}.tar.gz.sig
     steps:
       - name: Checkout trigger commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
           path: trigger
       - name: Checkout main repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           # TODO: maybe this should be main or configurable or something?
@@ -182,7 +182,7 @@ jobs:
           path: cargo-quickinstall
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: built-${{ inputs.build_os }}
           # TODO: check that we it can't write anywhere other than built.d
@@ -190,13 +190,13 @@ jobs:
 
       - name: Check if tarball exists
         id: check_files
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: ${{ env.BUILD_ARCHIVE }}
 
       - name: Cancel if no tarball
         if: steps.check_files.outputs.files_exists == 'false'
-        uses: andymckay/cancel-action@0.5
+        uses: andymckay/cancel-action@a955d435292c0d409d104b57d8e78435a93a6ef1 # 0.5
 
       - name: Wait for cancellation signal if no tarball
         if: steps.check_files.outputs.files_exists == 'false'
@@ -234,7 +234,7 @@ jobs:
 
       - name: Releasing assets in new release format
         if: "! inputs.skip_upload"
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.crate }}-${{ inputs.version }}
@@ -244,7 +244,7 @@ jobs:
 
       - name: Releasing assets signature in new release format
         if: "! inputs.skip_upload"
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.crate }}-${{ inputs.version }}
@@ -254,7 +254,7 @@ jobs:
 
       - name: Upload signature
         if: "! inputs.skip_signing"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signature
           path: ${{ env.SIG_FILENAME }}
@@ -270,13 +270,13 @@ jobs:
         shell: bash
     steps:
       - name: Checkout trigger branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
           ref: trigger/${{ inputs.target_arch }}
           path: trigger
       - name: Checkout trigger commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           path: cargo-quickinstall

--- a/.github/workflows/cronjob.yml
+++ b/.github/workflows/cronjob.yml
@@ -25,7 +25,7 @@ jobs:
     # but this action won't be doing any building so it's fine.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
 

--- a/.github/workflows/deploy-stats-server.yml
+++ b/.github/workflows/deploy-stats-server.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: deploy-group
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy stats-server --wait-timeout 1m
         env:

--- a/.github/workflows/deploy-stats-server.yml
+++ b/.github/workflows/deploy-stats-server.yml
@@ -14,7 +14,7 @@ jobs:
     concurrency: deploy-group
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: pcrockett/setup-fly@c59149fa58c215cf1e961bec2ffb53f0a21c2e85 # v0.1.0
       - run: flyctl deploy stats-server --wait-timeout 1m
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: MarcoIeni/release-plz-action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/selfbuild.yml
+++ b/.github/workflows/selfbuild.yml
@@ -38,7 +38,7 @@ jobs:
           - target_arch: armv7-unknown-linux-musleabihf
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -84,7 +84,7 @@ jobs:
           - target_arch: aarch64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install latest rust
@@ -125,7 +125,7 @@ jobs:
           - target_arch: aarch64-unknown-linux-musl
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
       - name: Fetch source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run shellcheck
         run: shellcheck *.sh
 
       - name: Cache shfmt compiled
         id: cache-shfmt
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/bin/shfmt
           key: ${{ runner.os }}-shfmt-4.4.1
@@ -53,12 +53,12 @@ jobs:
     steps:
       # TODO: actions/cache@v2?
       - name: Fetch source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Fetch tags required for testing
         run: git fetch --tags
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-all-crates: true
           workspaces: |
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Fetch source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install latest rust
         run: rustup toolchain install stable --no-self-update --profile minimal

--- a/.github/workflows/upgrade-transitive-deps.yml
+++ b/.github/workflows/upgrade-transitive-deps.yml
@@ -10,7 +10,7 @@ jobs:
     name: Upgrade & Open Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
 


### PR DESCRIPTION
_Since this project distributes a lot of software to a lot of people, and supply chain attacks seem to be all the rage lately._

This eliminates a lot of attack surface at little-to-no cost. Also a [documented best practice](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions).

I used [pinact](https://github.com/suzuki-shunsuke/pinact) to update and pin GitHub Actions:

```bash
pinact run --update
```

The cool thing about this is, Dependabot updates pinned actions as always, and updates the version comments correctly as well.